### PR TITLE
Feature: add datasets field to area store

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ installed on your machine.
 git clone https://github.com/Vizzuality/gfw-area-api.git
 cd gfw-area-api
 ./area.sh develop
-```text
 
 You can now access the microservice through the CT gateway.
 

--- a/app/src/models/area.model.js
+++ b/app/src/models/area.model.js
@@ -7,6 +7,7 @@ const Area = new Schema({
     geostore: { type: String, required: false, trim: true },
     wdpaid: { type: Number, required: false, trim: true },
     userId: { type: String, required: true, trim: true },
+    datasets: { type: Array, required: true, default: [] },
     createdAt: { type: Date, required: true, default: Date.now },
     image: { type: String, required: true, trim: true }
 });

--- a/app/src/routes/api/v1/area.router.js
+++ b/app/src/routes/api/v1/area.router.js
@@ -34,6 +34,7 @@ class AreaRouter {
             geostore: ctx.request.body.fields.geostore,
             wdpaid: ctx.request.body.fields.wdpaid,
             userId: ctx.state.loggedUser.id,
+            datasets: JSON.parse(ctx.request.body.fields.datasets),
             image
         }).save();
         ctx.body = AreaSerializer.serialize(area);
@@ -55,10 +56,14 @@ class AreaRouter {
             ctx.throw(400, 'Required geostore or wdpaid');
             return;
         }
-
+        if (ctx.request.body.fields.datasets) {
+            area.datasets = JSON.parse(ctx.request.body.fields.datasets);
+        }
         if (ctx.request.body.files && ctx.request.body.files.image) {
             area.image = await s3Service.uploadFile(ctx.request.body.files.image.path, ctx.request.body.files.image.name);
         }
+        area.updatedDate = Date.now;
+
         await area.save();
         ctx.body = AreaSerializer.serialize(area);
     }

--- a/app/src/serializers/area.serializer.js
+++ b/app/src/serializers/area.serializer.js
@@ -5,7 +5,7 @@ var JSONAPISerializer = require('jsonapi-serializer').Serializer;
 
 var areaSerializer = new JSONAPISerializer('area', {
     attributes: [
-        'name', 'geostore', 'wdpaid', 'userId', 'createdAt', 'image'
+        'name', 'geostore', 'wdpaid', 'userId', 'createdAt', 'image', 'datasets'
     ],
     resource: {
         attributes: ['type', 'content']

--- a/app/src/validators/area.validator.js
+++ b/app/src/validators/area.validator.js
@@ -8,6 +8,7 @@ class AreaValidator {
         ctx.checkBody('geostore').optional().isHexadecimal();
         ctx.checkBody('wdpaid').optional().isInt().toInt();
         ctx.checkFile('image').notEmpty();
+        ctx.checkFile('datasets').notEmpty();
 
         if (ctx.errors) {
             ctx.body = ErrorSerializer.serializeValidationBodyErrors(ctx.errors);
@@ -30,7 +31,7 @@ class AreaValidator {
         }
         await next();
     }
-    
+
 }
 
 module.exports = AreaValidator;

--- a/app/src/validators/area.validator.js
+++ b/app/src/validators/area.validator.js
@@ -8,7 +8,7 @@ class AreaValidator {
         ctx.checkBody('geostore').optional().isHexadecimal();
         ctx.checkBody('wdpaid').optional().isInt().toInt();
         ctx.checkFile('image').notEmpty();
-        ctx.checkFile('datasets').notEmpty();
+        ctx.checkFile('datasets').optional().toJson();
 
         if (ctx.errors) {
             ctx.body = ErrorSerializer.serializeValidationBodyErrors(ctx.errors);
@@ -23,6 +23,7 @@ class AreaValidator {
         ctx.checkBody('name').optional().len(2, 100);
         ctx.checkBody('geostore').optional().isHexadecimal();
         ctx.checkBody('wdpaid').optional().isInt();
+        ctx.checkFile('datasets').optional().toJson();
 
         if (ctx.errors) {
             ctx.body = ErrorSerializer.serializeValidationBodyErrors(ctx.errors);


### PR DESCRIPTION
Small update to add the fields Datasets (send as a JSON parsable string) and updated date to the areas:
- POST: accepts JSON.stringify field to datasets to save layers and their meta to the store
- UPDATE: accept JSON.stringify field to datasets as above, and also saves a new field, updatedDate to the store
- Sync these changes with the validator and the serializer.

That's all. Told you it was small.