### PR TITLE
Feat/geostore export

### DIFF
--- a/app/microservice/register.json
+++ b/app/microservice/register.json
@@ -10,6 +10,14 @@
 			"path": "/api/v2/area"
 		}
 	},{
+		"path": "/v2/export",
+		"method": "GET",
+		"authenticated": true,
+		"redirect": {
+			"method": "GET",
+			"path": "/api/v2/export"
+		}
+	},{
         "path": "/v2/area/fw",
         "method": "GET",
         "authenticated": true,

--- a/app/src/routes/api/v2/area.router.js
+++ b/app/src/routes/api/v2/area.router.js
@@ -18,8 +18,33 @@ class AreaRouterV2 {
         if (ctx.query.application) {
             filter.application = ctx.query.application.split(',').map(el => el.trim());
         }
+        if (ctx.query.status) {
+            filter.status = ctx.query.status.trim();
+        }
+        if (ctx.query.public) {
+            const public_filter = ctx.query.public.trim().toLowerCase() == 'true' ? true : false;
+            filter.public = public_filter;
+        }
         const areas = await AreaModel.find(filter);
         ctx.body = AreaSerializerV2.serialize(areas);
+    }
+
+    static async getExport(ctx) {
+        logger.info('Exporting areas of the user ', ctx.state.loggedUser.id);
+        const filter = { userId: ctx.state.loggedUser.id };
+        if (ctx.query.application) {
+            filter.application = ctx.query.application.split(',').map(el => el.trim());
+        }
+        if (ctx.query.status) {
+            filter.status = ctx.query.status.trim();
+        }
+        if (ctx.query.public) {
+            const public_filter = ctx.query.public.trim().toLowerCase() == 'true' ? true : false;
+            filter.public = public_filter;
+        }
+        const areas = await AreaModel.find(filter);
+        const geostores =  areas.map(el => {return {id: el.id, geostore: el.geostore}});
+        ctx.body = AreaSerializerV2.serialize(geostores);
     }
 
     static async updateByGeostore(ctx) {
@@ -369,6 +394,7 @@ async function checkPermission(ctx, next) {
 }
 
 router.get('/', loggedUserToState, AreaRouterV2.getAll);
+router.get('/export', loggedUserToState, AreaRouterV2.getExport);
 router.post('/', loggedUserToState, AreaValidatorV2.create, AreaRouterV2.save);
 router.patch('/:id', loggedUserToState, checkPermission, AreaValidatorV2.update, AreaRouterV2.update);
 router.get('/:id', loggedUserToState, AreaRouterV2.get);

--- a/app/src/routes/api/v2/area.router.js
+++ b/app/src/routes/api/v2/area.router.js
@@ -39,8 +39,7 @@ class AreaRouterV2 {
             filter.status = ctx.query.status.trim();
         }
         if (ctx.query.public) {
-            const public_filter = ctx.query.public.trim().toLowerCase() == 'true' ? true : false;
-            filter.public = public_filter;
+            filter.public = ctx.query.public.trim().toLowerCase() == 'true' ? true : false;
         }
         const areas = await AreaModel.find(filter);
         const geostores =  areas.map(el => {return {id: el.id, geostore: el.geostore}});

--- a/app/src/services/s3.service.js
+++ b/app/src/services/s3.service.js
@@ -3,6 +3,7 @@ const AWS = require('aws-sdk');
 const fs = require('fs');
 const config = require('config');
 const uuidV4 = require('uuid/v4');
+const moment = require('moment')
 
 AWS.config.update({
     accessKeyId: config.get('s3.accessKeyId'),
@@ -44,6 +45,29 @@ class S3Service {
                     logger.debug('File uploaded successfully', resp);
                     resolve(`https://s3.amazonaws.com/${config.get('s3.bucket')}/${config.get('s3.folder')}/${uuid}.${ext}`);
                 });
+            });
+        });
+    }
+
+    async uploadJson(data) {
+        logger.info(`Uploading file json`);
+        return new Promise((resolve, reject) => {
+            //bucket = gfw-pipelines/
+            //key = tiggers/emr/aoi/<yyyymmdd>
+            const date = moment().format("YYYYMMDD");
+            this.s3.upload({
+                Bucket: config.get('s3.bucket'),
+                Key: `${config.get('s3.folder')}/${date}.json`,
+                Body: data,
+                ACL: 'public-read'
+            }, (resp) => {
+                if (resp && resp.statusCode >= 300) {
+                    logger.error(resp);
+                    reject(resp);
+                    return;
+                }
+                logger.debug('File uploaded successfully', resp);
+                resolve(`https://s3.amazonaws.com/${config.get('s3.bucket')}/${config.get('s3.folder')}/${date}.json`);
             });
         });
     }


### PR DESCRIPTION
# Summary

Adds  `GET` `/v2/area/export` endpoint.

This endpoint is used to export areas to S3 bucket in json format. Areas can be filtered by `status` and `public` properties.

- Uses query params to filter Areas database
- Posts returned areas json

# Todo

- Setup correct S3 credentials to post to correct bucket/key
- Report successful posts to S3 in response