### PR TITLE
Add get all by admin

### DIFF
--- a/app/src/routes/api/v2/area.router.js
+++ b/app/src/routes/api/v2/area.router.js
@@ -11,14 +11,28 @@ const router = new Router({
     prefix: '/area',
 });
 
+function getFilters(ctx) {
+    let filter = { userId: ctx.state.loggedUser.id };
+    const all = ctx.query.all && ctx.query.all.trim().toLowerCase() === 'true';
+    if (ctx.state.loggedUser.role === 'ADMIN' && all) filter = {};
+    if (ctx.query.application) {
+        filter.application = ctx.query.application.split(',').map((el) => el.trim());
+    }
+    if (ctx.query.status) {
+        filter.status = ctx.query.status.trim();
+    }
+    if (ctx.query.public) {
+        const publicFilter = ctx.query.public.trim().toLowerCase() === 'true';
+        filter.public = publicFilter;
+    }
+    return filter;
+}
+
 class AreaRouterV2 {
 
     static async getAll(ctx) {
         logger.info('Obtaining all areas of the user ', ctx.state.loggedUser.id);
-        const filter = { userId: ctx.state.loggedUser.id };
-        if (ctx.query.application) {
-            filter.application = ctx.query.application.split(',').map((el) => el.trim());
-        }
+        const filter = getFilters(ctx)
         const areas = await AreaModel.find(filter);
         ctx.body = AreaSerializerV2.serialize(areas);
     }


### PR DESCRIPTION
Allows users get to received areas filtered by key word arguments e.g. `?status=pending`

Admin users may also use `all=true` to retrieve all user areas.