### PR TITLE
Feature/mutipleareas

### DIFF
--- a/app/microservice/register.json
+++ b/app/microservice/register.json
@@ -161,6 +161,14 @@
 			"path": "/api/v1/area/:id/alerts"
 		}
 	},{
+		"path": "/v1/area/find/:id",
+		"method": "GET",
+		"authenticated": true,
+		"redirect": {
+			"method": "GET",
+			"path": "/api/v1/area/find/:id"
+		}
+	},{
 		"path": "/v1/download-tiles/:geostoreId/:minZoom/:maxZoom",
 		"method": "GET",
 		"redirect": {

--- a/app/src/models/area.model.js
+++ b/app/src/models/area.model.js
@@ -33,8 +33,8 @@ const Area = new Schema({
     datasets: [Dataset],
     createdAt: { type: Date, required: true, default: Date.now },
     image: { type: String, required: false, trim: true },
-    templateId: { type: String, trim: true, required: false }
-});
+    templateId: { type: String, trim: true, required: false },
+    templateIds: {type: Array, required: false, default: []  }});
 
 
 module.exports = mongoose.model('Area', Area);

--- a/app/src/routes/api/v1/area.router.js
+++ b/app/src/routes/api/v1/area.router.js
@@ -181,9 +181,10 @@ class AreaRouter {
                 );
             }else{
                 let singleTemplateId = ctx.request.body.templateId[0];
-                // backward compatibility
+                // backward compatibility - templateIds is the new version
+                // templateId is for backward compatibility
                 area.templateId = (singleTemplateId);
-                area.templateIds.push(ctx.request.body.templateId);
+                area.templateIds.addToSet(ctx.request.body.templateId);
             }
         }
         area.updatedDate = Date.now;

--- a/app/src/routes/api/v1/area.router.js
+++ b/app/src/routes/api/v1/area.router.js
@@ -83,11 +83,22 @@ class AreaRouter {
         await AreaRouter.saveArea(ctx, ctx.params.userId);
     }
 
+    // returns all area ID's which include the templateID given
+    static async getAOIs(ctx) {
+        const area = await AreaModel.find( { $or:[ { 'templateIds' : ctx.params.id}, { 'templateId' : ctx.params.id} ]}, {
+            _id: 1
+        });
+        ctx.body = AreaSerializer.serialize(area);
+    }
+
+
     static async saveArea(ctx, userId) {
         logger.info('Saving area');
         let image = '';
         if (ctx.request.files && ctx.request.files.image) {
             image = await s3Service.uploadFile(ctx.request.files.image.path, ctx.request.files.image.name);
+        }else{
+            image = 'https://glowvarietyshow.com/wp-content/uploads/2017/03/placeholder-image.jpg';
         }
         let datasets = [];
         if (ctx.request.body.datasets) {
@@ -152,15 +163,32 @@ class AreaRouter {
         if (ctx.request.body.datasets) {
             area.datasets = JSON.parse(ctx.request.body.datasets);
         }
+        // image fall back
         if (files && files.image) {
             area.image = await s3Service.uploadFile(files.image.path, files.image.name);
+        }else {
+            area.image = 'https://glowvarietyshow.com/wp-content/uploads/2017/03/placeholder-image.jpg';
         }
         if (typeof ctx.request.body.templateId !== 'undefined') {
-            area.templateId = ctx.request.body.templateId;
+
+            if (ctx.request.body.override === true){
+                logger.debug('debug', ctx.request.body.templateId);
+
+                let templateId = ctx.request.body.templateId;
+                const areas = await AreaModel.findOneAndUpdate(
+                    { "_id" : ctx.params.id} ,
+                    { "$pull" : { "templateIds" : templateId.toString()  } }
+                );
+            }else{
+                let singleTemplateId = ctx.request.body.templateId[0];
+                // backward compatibility
+                area.templateId = (singleTemplateId);
+                area.templateIds.push(ctx.request.body.templateId);
+            }
         }
         area.updatedDate = Date.now;
 
-        await area.save();
+        await area();
         ctx.body = AreaSerializer.serialize(area);
     }
 
@@ -276,6 +304,7 @@ async function unwrapJSONStrings(ctx, next) {
 
 router.post('/', loggedUserToState, unwrapJSONStrings, AreaValidator.create, AreaRouter.save);
 router.patch('/:id', loggedUserToState, checkPermission, unwrapJSONStrings, AreaValidator.update, AreaRouter.update);
+router.get('/find/:id', loggedUserToState, AreaRouter.getAOIs);
 router.get('/', loggedUserToState, AreaRouter.getAll);
 router.get('/fw', loggedUserToState, AreaRouter.getFWAreas);
 router.post('/fw/:userId', loggedUserToState, AreaValidator.create, AreaRouter.saveByUserId);

--- a/app/src/serializers/area.serializer.js
+++ b/app/src/serializers/area.serializer.js
@@ -12,7 +12,8 @@ const areaSerializer = new JSONAPISerializer('area', {
         'datasets',
         'use',
         'iso',
-        'templateId'
+        'templateId',
+        'templateIds'
     ],
     resource: {
         attributes: ['type', 'content']

--- a/app/src/services/download.service.js
+++ b/app/src/services/download.service.js
@@ -127,11 +127,21 @@ class DownloadService {
                 }
             }
             if (promises.length > 0) {
-                await Promise.all(promises);
+                // map the promises which error to the error promise array, retry those requests.
+                // If they fail then catch them as null
+                // This will result in missing tiles however will not fall over
+                let errors = [];
+                await Promise.all(promises.map(p => p.catch(error => errors.push(p))));
+                if (errors.length > 0){
+                    await Promise.all(errors.map(p => p.catch(error => null)));
+                    logger.debug(errors)
+                }
                 promises = null;
             }
             // eslint-disable-next-line no-empty
-        } catch (err) {}
+        } catch (err) {
+            logger.debug(err)
+        }
         await DownloadService.zipFolder(tmpobj.name, `${tmpDownload.name}/download.zip`);
         logger.info('Removing file ', tmpobj.name);
         await DownloadService.removeFolder(tmpobj.name);


### PR DESCRIPTION
------- Issues to change 


-- Downloading tile error 
change in file download.service.js 
the problem being in function downloadAndZipCoordinates()
due to using promises.all if one of the requests fails, they all fall over. 
I suggest to map the requests which fail to a new promise array, then we try and request the error promise again. If it fails again, just set it to null. Thereby returning something rather than failing all-together. 

-- Grab areas with template id 
I have created a new endpoint, /find/:id. This is applied in getAOIs, it grabs the area ID's which contain the template ID's from is requested form the form microservice.

-- image fallback 
A image placeholder was provided it cases the snapshot cannot be taken.

-- multiple areas of interest 
Most of the work here is in the update function. When the request comes with the property 'override'  the model will update accordingly overriding the the templateIDs array with the new area of interest. 

If it a template with no area of interest then it will just add to the area like normal.

-- model change -- backward compatibility
IMPORTANT

The issue we will have is  backward compatibility with the fields, the model has been updated with templateID : string (this is the original field) and templateIDs : array (this is the new field). All new frontends will utilise templateIDs, however we have to keep templateID as older devices who have not updated will require the old property. This is more for read purposes the write purposes, when writing it will write to both properties however the actual value in the old property is not important and will just pick one form the array. 
