### PR TITLE
Fix all=true filter for v2 areas router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 16/03/2020
+
+- Fix all=true filter for v2 areas router - using endpoint to find all subscriptions in MS Subscriptions.
+
 # v1.1.0
 
 ## 06/03/2020

--- a/app/src/services/subscription.service.js
+++ b/app/src/services/subscription.service.js
@@ -42,6 +42,16 @@ class SubscriptionsService {
         return {};
     }
 
+    static async getAllSubscriptions() {
+        const response = await ctRegisterMicroservice.requestToMicroservice({
+            uri: `/subscriptions/admin/find-all`,
+            method: 'GET',
+            json: true,
+        });
+
+        return response.data;
+    }
+
     static async getUserSubscriptions(userId) {
         const response = await ctRegisterMicroservice.requestToMicroservice({
             uri: `/subscriptions/user/${userId}`,

--- a/app/test/e2e/utils/helpers.js
+++ b/app/test/e2e/utils/helpers.js
@@ -131,6 +131,38 @@ const mockSubscriptionFindForUser = (userId, idsList = []) => {
         }));
 };
 
+const mockSubscriptionFindAll = (ids = [], overrideArray = {}) => {
+    nock(process.env.CT_URL)
+        .get(`/v1/subscriptions/admin/find-all`)
+        .reply(200, () => ({
+            data: ids.map((id, idx) => {
+                const overrideData = overrideArray[idx] || {};
+                return {
+                    type: 'subscription',
+                    id,
+                    attributes: {
+                        name: 'Subscription Name',
+                        createdAt: '2020-02-06T11:27:43.751Z',
+                        userId: '5dd7b92abf56ca0011875ae2',
+                        resource: { type: 'EMAIL', content: 'henrique.pacheco@vizzuality.com' },
+                        datasets: ['63f34231-7369-4622-81f1-28a144d17835'],
+                        params: {},
+                        confirmed: true,
+                        language: 'en',
+                        datasetsQuery: [{
+                            threshold: 1,
+                            lastSentDate: '2020-02-06T11:27:43.751Z',
+                            historical: [],
+                            type: 'undefined'
+                        }],
+                        env: 'production',
+                        ...overrideData
+                    }
+                };
+            })
+        }));
+};
+
 module.exports = {
     createArea,
     getUUID,
@@ -139,4 +171,5 @@ module.exports = {
     mockSubscriptionDeletion,
     mockSubscriptionFindByIds,
     mockSubscriptionFindForUser,
+    mockSubscriptionFindAll,
 };


### PR DESCRIPTION
This PR fixes the all=true filter when requesting v2 areas not fetching all existing subscriptions.

This PR should be deployed at the same time as https://github.com/gfw-api/gfw-subscription-api/pull/55

Associated docs PR: https://github.com/resource-watch/doc-api/pull/130