### PR TITLE
Calculate the appropriate status for v2 areas

### DIFF
--- a/app/test/e2e/utils/helpers.js
+++ b/app/test/e2e/utils/helpers.js
@@ -87,7 +87,7 @@ const mockSubscriptionFindByIds = (ids = [], overrideData = {}) => {
                     userId: '5dd7b92abf56ca0011875ae2',
                     resource: { type: 'EMAIL', content: 'henrique.pacheco@vizzuality.com' },
                     datasets: ['63f34231-7369-4622-81f1-28a144d17835'],
-                    params: {},
+                    params: { geostore: '123' },
                     confirmed: true,
                     language: 'en',
                     datasetsQuery: [{

--- a/app/test/e2e/v2/area-status.spec.js
+++ b/app/test/e2e/v2/area-status.spec.js
@@ -71,15 +71,16 @@ describe('Area v2 status', () => {
     it('Getting an area that does not exist in the areas database returns areas with the correct status - CASE 3', async () => {
         // CASE 3: Any other case, test area should have status saved
         const id = new mongoose.Types.ObjectId();
-        const testArea = await new Area(createArea({ userId: USERS.USER.id, wdpaid: '123', subscriptionId: id.toHexString() })).save();
+        const testArea = await new Area(createArea({ userId: USERS.USER.id, subscriptionId: id.toHexString() })).save();
 
         // Mock the test area
-        mockSubscriptionFindByIds([id], { userId: USERS.USER.id });
+        mockSubscriptionFindByIds([id], { userId: USERS.USER.id, params: { wdpaid: '123' } });
         const response = await requester.get(`/api/v2/area/${testArea.id}?loggedUser=${JSON.stringify(USERS.USER)}`);
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('object');
         response.body.data.should.have.property('attributes').and.be.an('object');
         response.body.data.attributes.should.have.property('subscriptionId').and.equal(id.toHexString());
+        response.body.data.attributes.should.have.property('wdpaid').and.equal(123);
         response.body.data.attributes.should.have.property('status').and.equal('saved');
     });
 

--- a/app/test/e2e/v2/area-status.spec.js
+++ b/app/test/e2e/v2/area-status.spec.js
@@ -1,0 +1,93 @@
+const nock = require('nock');
+const chai = require('chai');
+const mongoose = require('mongoose');
+
+const Area = require('models/area.modelV2');
+const { createArea } = require('../utils/helpers');
+const { USERS } = require('../utils/test.constants');
+const { getTestServer } = require('../utils/test-server');
+const { mockSubscriptionFindByIds } = require('../utils/helpers');
+
+chai.should();
+nock.disableNetConnect();
+nock.enableNetConnect(process.env.HOST_IP);
+const requester = getTestServer();
+
+describe('Area v2 status', () => {
+    before(() => {
+        if (process.env.NODE_ENV !== 'test') {
+            throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
+        }
+    });
+
+    it('Getting an area that exists in the areas database always returns the status saved in the database', async () => {
+        const savedArea = await new Area(createArea({ userId: USERS.USER.id, status: 'saved' })).save();
+        const pendingArea = await new Area(createArea({ userId: USERS.USER.id, status: 'pending' })).save();
+
+        const savedResponse = await requester.get(`/api/v2/area/${savedArea.id}?loggedUser=${JSON.stringify(USERS.USER)}`);
+        savedResponse.status.should.equal(200);
+        savedResponse.body.should.have.property('data').and.be.an('object');
+        savedResponse.body.data.should.have.property('attributes').and.be.an('object');
+        savedResponse.body.data.attributes.should.have.property('status').and.equal('saved');
+
+        const pendingResponse = await requester.get(`/api/v2/area/${pendingArea.id}?loggedUser=${JSON.stringify(USERS.USER)}`);
+        pendingResponse.status.should.equal(200);
+        pendingResponse.body.should.have.property('data').and.be.an('object');
+        pendingResponse.body.data.should.have.property('attributes').and.be.an('object');
+        pendingResponse.body.data.attributes.should.have.property('status').and.equal('pending');
+    });
+
+    it('Getting an area that does not exist in the areas database returns areas with the correct status - CASE 1', async () => {
+        // CASE 1: Test area refers to a geostore, and exists at least one area for the same geostore with status saved
+        // Test area should have status saved
+        await new Area(createArea({ userId: USERS.USER.id, geostore: '123', status: 'saved' })).save();
+
+        // Mock the test area
+        const id = new mongoose.Types.ObjectId();
+        mockSubscriptionFindByIds([id], { userId: USERS.USER.id });
+        const response = await requester.get(`/api/v2/area/${id}?loggedUser=${JSON.stringify(USERS.USER)}`);
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('object');
+        response.body.data.should.have.property('attributes').and.be.an('object');
+        response.body.data.attributes.should.have.property('subscriptionId').and.equal(id.toHexString());
+        response.body.data.attributes.should.have.property('status').and.equal('saved');
+    });
+
+    it('Getting an area that does not exist in the areas database returns areas with the correct status - CASE 2', async () => {
+        // CASE 2: Test area refers to a geostore, and there does NOT exist one area for the same geostore with status saved
+        // Test area should have status pending
+
+        // Mock the test area
+        const id = new mongoose.Types.ObjectId();
+        mockSubscriptionFindByIds([id], { userId: USERS.USER.id });
+        const response = await requester.get(`/api/v2/area/${id}?loggedUser=${JSON.stringify(USERS.USER)}`);
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('object');
+        response.body.data.should.have.property('attributes').and.be.an('object');
+        response.body.data.attributes.should.have.property('subscriptionId').and.equal(id.toHexString());
+        response.body.data.attributes.should.have.property('status').and.equal('pending');
+    });
+
+    it('Getting an area that does not exist in the areas database returns areas with the correct status - CASE 3', async () => {
+        // CASE 3: Any other case, test area should have status saved
+        const id = new mongoose.Types.ObjectId();
+        const testArea = await new Area(createArea({ userId: USERS.USER.id, wdpaid: '123', subscriptionId: id.toHexString() })).save();
+
+        // Mock the test area
+        mockSubscriptionFindByIds([id], { userId: USERS.USER.id });
+        const response = await requester.get(`/api/v2/area/${testArea.id}?loggedUser=${JSON.stringify(USERS.USER)}`);
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('object');
+        response.body.data.should.have.property('attributes').and.be.an('object');
+        response.body.data.attributes.should.have.property('subscriptionId').and.equal(id.toHexString());
+        response.body.data.attributes.should.have.property('status').and.equal('saved');
+    });
+
+    afterEach(async () => {
+        if (!nock.isDone()) {
+            throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);
+        }
+
+        await Area.deleteMany({}).exec();
+    });
+});


### PR DESCRIPTION
This PR fixes a problem with the status of areas, where areas were being returned always having `saved` status, reported by @edbrett [via Slack here](https://vizzuality.slack.com/archives/C0633T0LC/p1585595735050000).

The fix takes into account the type of area being handled, setting the status to `pending` **if the area refers to a geostore and there are no other areas referring to the same geostore with status `saved`**. In any other case, the area should have the status set to `saved`.

Tests were added to cover this behavior.