### PR TITLE
Fix/update email template ids

### DIFF
--- a/app/src/routes/api/v2/area.router.js
+++ b/app/src/routes/api/v2/area.router.js
@@ -403,7 +403,7 @@ class AreaRouterV2 {
             const { email, application } = area;
             const lang = area.language || 'en';
             await MailService.sendMail(
-                `subscription-preference-change-${lang}-copy`,
+                `subscription-preference-change-${lang}`,
                 getEmailParametersFromArea(area),
                 [{ address: email }],
                 application

--- a/app/src/routes/api/v2/area.router.js
+++ b/app/src/routes/api/v2/area.router.js
@@ -279,7 +279,7 @@ class AreaRouterV2 {
             const { application, status, language } = area;
             const lang = language || 'en';
             await MailService.sendMail(
-                status === 'pending' ? `dashboard-pending-${lang}-copy` : `dashboard-complete-${lang}-copy`,
+                status === 'pending' ? `dashboard-pending-${lang}` : `dashboard-complete-${lang}`,
                 getEmailParametersFromArea(area),
                 [{ address: area.email }],
                 application
@@ -480,7 +480,7 @@ class AreaRouterV2 {
                 }
 
                 return MailService.sendMail(
-                    `dashboard-complete-${lang}-copy`,
+                    `dashboard-complete-${lang}`,
                     getEmailParametersFromArea(area),
                     [{ address: email }],
                     application

--- a/app/test/e2e/v2/area-emails.spec.js
+++ b/app/test/e2e/v2/area-emails.spec.js
@@ -139,7 +139,7 @@ describe('V2 Area emails', () => {
         sinon.assert.calledOnce(fake);
         sinon.assert.calledWith(
             fake,
-            'subscription-preference-change-en-copy',
+            'subscription-preference-change-en',
             getEmailParameters(response.body.data.id, attributes),
             [{ address: attributes.email }],
             attributes.application,

--- a/app/test/e2e/v2/area-emails.spec.js
+++ b/app/test/e2e/v2/area-emails.spec.js
@@ -65,7 +65,7 @@ describe('V2 Area emails', () => {
         sinon.assert.calledOnce(fake);
         sinon.assert.calledWith(
             fake,
-            'dashboard-complete-en-copy',
+            'dashboard-complete-en',
             getEmailParameters(response.body.data.id, attributes),
             [{ address: attributes.email }],
             attributes.application,
@@ -93,7 +93,7 @@ describe('V2 Area emails', () => {
         sinon.assert.calledOnce(fake);
         sinon.assert.calledWith(
             fake,
-            'dashboard-pending-en-copy',
+            'dashboard-pending-en',
             getEmailParameters(response.body.data.id, attributes),
             [{ address: attributes.email }],
             attributes.application,
@@ -171,7 +171,7 @@ describe('V2 Area emails', () => {
 
         sinon.assert.calledWith(
             fake,
-            'dashboard-complete-en-copy',
+            'dashboard-complete-en',
             getEmailParameters(response.body.data[0].id, area1Attributes),
             [{ address: area1Attributes.email }],
             area1Attributes.application,
@@ -179,7 +179,7 @@ describe('V2 Area emails', () => {
 
         sinon.assert.calledWith(
             fake,
-            'dashboard-complete-en-copy',
+            'dashboard-complete-en',
             getEmailParameters(response.body.data[1].id, area2Attributes),
             [{ address: area2Attributes.email }],
             area2Attributes.application,


### PR DESCRIPTION
Updates the templates strings for
- `dashboard-pending-{lang}`
- `dashboard-complete-{lang}`
- `subscription-preference-change-{lang}`
