### PR TITLE
Add confirmed field to all endpoint responses of areas

### DIFF
--- a/app/src/services/subscription.service.js
+++ b/app/src/services/subscription.service.js
@@ -4,6 +4,18 @@ const AreaModel = require('models/area.modelV2');
 
 class SubscriptionsService {
 
+    static async mergeSubscriptionSpecificProps(area) {
+        // Find any subscription only props (such as confirmed) and merge them to the area being returned
+        if (area.subscriptionId) {
+            const [sub] = await SubscriptionsService.findByIds([area.subscriptionId]);
+            return SubscriptionsService.mergeSubscriptionOverArea(area, sub.attributes);
+        }
+
+        // Merge default values and return the area
+        area.confirmed = false;
+        return area;
+    }
+
     static getRequestBodyForSubscriptionFromArea(area) {
         const body = {
             name: area.name,

--- a/app/src/services/subscription.service.js
+++ b/app/src/services/subscription.service.js
@@ -8,7 +8,7 @@ class SubscriptionsService {
         // Find any subscription only props (such as confirmed) and merge them to the area being returned
         if (area.subscriptionId) {
             const [sub] = await SubscriptionsService.findByIds([area.subscriptionId]);
-            return SubscriptionsService.mergeSubscriptionOverArea(area, sub.attributes);
+            return SubscriptionsService.mergeSubscriptionOverArea(area, { ...sub.attributes, id: sub.id });
         }
 
         // Merge default values and return the area

--- a/app/test/e2e/utils/helpers.js
+++ b/app/test/e2e/utils/helpers.js
@@ -74,9 +74,10 @@ const mockSubscriptionDeletion = (id = '123') => {
     nock(process.env.CT_URL).delete(`/v1/subscriptions/${id}`).reply(200);
 };
 
-const mockSubscriptionFindByIds = (ids = [], overrideData = {}) => {
+const mockSubscriptionFindByIds = (ids = [], overrideData = {}, times = 1) => {
     nock(process.env.CT_URL)
         .post(`/v1/subscriptions/find-by-ids`)
+        .times(times)
         .reply(200, () => ({
             data: ids.map((id) => ({
                 type: 'subscription',

--- a/app/test/e2e/v2/area-status.spec.js
+++ b/app/test/e2e/v2/area-status.spec.js
@@ -44,7 +44,7 @@ describe('V2 - Area status', () => {
 
         // Mock the test area
         const id = new mongoose.Types.ObjectId();
-        mockSubscriptionFindByIds([id], { userId: USERS.USER.id });
+        mockSubscriptionFindByIds([id], { userId: USERS.USER.id }, 2);
         const response = await requester.get(`/api/v2/area/${id}?loggedUser=${JSON.stringify(USERS.USER)}`);
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('object');
@@ -59,7 +59,7 @@ describe('V2 - Area status', () => {
 
         // Mock the test area
         const id = new mongoose.Types.ObjectId();
-        mockSubscriptionFindByIds([id], { userId: USERS.USER.id });
+        mockSubscriptionFindByIds([id], { userId: USERS.USER.id }, 2);
         const response = await requester.get(`/api/v2/area/${id}?loggedUser=${JSON.stringify(USERS.USER)}`);
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('object');
@@ -78,7 +78,7 @@ describe('V2 - Area status', () => {
         })).save();
 
         // Mock the test area
-        mockSubscriptionFindByIds([id], { userId: USERS.USER.id, params: { wdpaid: '123' } });
+        mockSubscriptionFindByIds([id], { userId: USERS.USER.id, params: { wdpaid: '123' } }, 2);
         const response = await requester.get(`/api/v2/area/${testArea.id}?loggedUser=${JSON.stringify(USERS.USER)}`);
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('object');
@@ -98,7 +98,7 @@ describe('V2 - Area status', () => {
         })).save();
 
         // Mock the test area
-        mockSubscriptionFindByIds([subId.toHexString()], { userId: USERS.USER.id });
+        mockSubscriptionFindByIds([subId.toHexString()], { userId: USERS.USER.id }, 2);
         const response = await requester.get(`/api/v2/area/${testArea.id}?loggedUser=${JSON.stringify(USERS.USER)}`);
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('object');

--- a/app/test/e2e/v2/area-status.spec.js
+++ b/app/test/e2e/v2/area-status.spec.js
@@ -43,13 +43,13 @@ describe('V2 - Area status', () => {
         await new Area(createArea({ userId: USERS.USER.id, geostore: '123', status: 'saved' })).save();
 
         // Mock the test area
-        const id = new mongoose.Types.ObjectId();
+        const id = new mongoose.Types.ObjectId().toString();
         mockSubscriptionFindByIds([id], { userId: USERS.USER.id }, 2);
         const response = await requester.get(`/api/v2/area/${id}?loggedUser=${JSON.stringify(USERS.USER)}`);
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('object');
         response.body.data.should.have.property('attributes').and.be.an('object');
-        response.body.data.attributes.should.have.property('subscriptionId').and.equal(id.toHexString());
+        response.body.data.attributes.should.have.property('subscriptionId').and.equal(id);
         response.body.data.attributes.should.have.property('status').and.equal('saved');
     });
 
@@ -58,23 +58,23 @@ describe('V2 - Area status', () => {
         // Test area should have status pending
 
         // Mock the test area
-        const id = new mongoose.Types.ObjectId();
+        const id = new mongoose.Types.ObjectId().toString();
         mockSubscriptionFindByIds([id], { userId: USERS.USER.id }, 2);
         const response = await requester.get(`/api/v2/area/${id}?loggedUser=${JSON.stringify(USERS.USER)}`);
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('object');
         response.body.data.should.have.property('attributes').and.be.an('object');
-        response.body.data.attributes.should.have.property('subscriptionId').and.equal(id.toHexString());
+        response.body.data.attributes.should.have.property('subscriptionId').and.equal(id);
         response.body.data.attributes.should.have.property('status').and.equal('pending');
     });
 
     it('Getting an area that exists in the areas database returns areas with the correct status - CASE 3', async () => {
         // CASE 3: Any other case, test area should have status saved
-        const id = new mongoose.Types.ObjectId();
+        const id = new mongoose.Types.ObjectId().toString();
         const testArea = await new Area(createArea({
             userId: USERS.USER.id,
             status: 'saved',
-            subscriptionId: id.toHexString()
+            subscriptionId: id,
         })).save();
 
         // Mock the test area
@@ -83,27 +83,27 @@ describe('V2 - Area status', () => {
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('object');
         response.body.data.should.have.property('attributes').and.be.an('object');
-        response.body.data.attributes.should.have.property('subscriptionId').and.equal(id.toHexString());
+        response.body.data.attributes.should.have.property('subscriptionId').and.equal(id);
         response.body.data.attributes.should.have.property('wdpaid').and.equal(123);
         response.body.data.attributes.should.have.property('status').and.equal('saved');
     });
 
     it('Getting an area that has status \'pending\' in the database but has geostore and attached subscription should return the correct status - pending', async () => {
-        const subId = new mongoose.Types.ObjectId();
+        const subId = new mongoose.Types.ObjectId().toString();
         const testArea = await new Area(createArea({
             userId: USERS.USER.id,
             status: 'pending',
             geostore: '123',
-            subscriptionId: subId.toHexString(),
+            subscriptionId: subId,
         })).save();
 
         // Mock the test area
-        mockSubscriptionFindByIds([subId.toHexString()], { userId: USERS.USER.id }, 2);
+        mockSubscriptionFindByIds([subId], { userId: USERS.USER.id }, 2);
         const response = await requester.get(`/api/v2/area/${testArea.id}?loggedUser=${JSON.stringify(USERS.USER)}`);
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('object');
         response.body.data.should.have.property('attributes').and.be.an('object');
-        response.body.data.attributes.should.have.property('subscriptionId').and.equal(subId.toHexString());
+        response.body.data.attributes.should.have.property('subscriptionId').and.equal(subId);
         response.body.data.attributes.should.have.property('status').and.equal('pending');
     });
 

--- a/app/test/e2e/v2/create-area.spec.js
+++ b/app/test/e2e/v2/create-area.spec.js
@@ -11,7 +11,7 @@ const { USERS } = require('../utils/test.constants');
 chai.should();
 
 const { getTestServer } = require('../utils/test-server');
-const { mockSubscriptionCreation } = require('../utils/helpers');
+const { mockSubscriptionCreation, mockSubscriptionFindByIds } = require('../utils/helpers');
 
 nock.disableNetConnect();
 nock.enableNetConnect(process.env.HOST_IP);
@@ -125,6 +125,7 @@ describe('V2 - Create area', () => {
 
     it('Creating an area with fires alerts on triggers a request to create a subscription and should return a 200 HTTP code and the created area object', async () => {
         mockSubscriptionCreation('5e3bf82fad36f4001abe150e');
+        mockSubscriptionFindByIds(['5e3bf82fad36f4001abe150e'], { userId: USERS.USER.id });
 
         const response = await requester.post(`/api/v2/area`).send({
             loggedUser: USERS.USER,
@@ -142,6 +143,7 @@ describe('V2 - Create area', () => {
 
     it('Creating an area with deforestation alerts on triggers a request to create a subscription and should return a 200 HTTP code and the created area object', async () => {
         mockSubscriptionCreation('5e3bf82fad36f4001abe150e');
+        mockSubscriptionFindByIds(['5e3bf82fad36f4001abe150e'], { userId: USERS.USER.id });
 
         const response = await requester.post(`/api/v2/area`).send({
             loggedUser: USERS.USER,
@@ -159,6 +161,7 @@ describe('V2 - Create area', () => {
 
     it('Creating an area with monthly summary alerts on triggers a request to create a subscription and should return a 200 HTTP code and the created area object', async () => {
         mockSubscriptionCreation('5e3bf82fad36f4001abe150e');
+        mockSubscriptionFindByIds(['5e3bf82fad36f4001abe150e'], { userId: USERS.USER.id });
 
         const response = await requester.post(`/api/v2/area`).send({
             loggedUser: USERS.USER,

--- a/app/test/e2e/v2/get-area.spec.js
+++ b/app/test/e2e/v2/get-area.spec.js
@@ -70,15 +70,15 @@ describe('V2 - Get areas', () => {
     });
 
     it('Getting areas having some subscriptions related to areas should return a 200 OK with all the areas and subscriptions for the current user', async () => {
-        const subId1 = new mongoose.Types.ObjectId();
-        const subId2 = new mongoose.Types.ObjectId();
+        const subId1 = new mongoose.Types.ObjectId().toString();
+        const subId2 = new mongoose.Types.ObjectId().toString();
 
-        mockSubscriptionFindForUser(USERS.USER.id, [subId1.toHexString(), subId2.toHexString()]);
-        mockSubscriptionFindByIds([subId1.toString()], { userId: USERS.USER.id });
-        mockSubscriptionFindByIds([subId2.toString()], { userId: USERS.USER.id });
+        mockSubscriptionFindForUser(USERS.USER.id, [subId1, subId2]);
+        mockSubscriptionFindByIds([subId1], { userId: USERS.USER.id });
+        mockSubscriptionFindByIds([subId2], { userId: USERS.USER.id });
 
         const area = await new Area(createArea({ userId: USERS.USER.id })).save();
-        await new Area(createArea({ userId: USERS.USER.id, subscriptionId: subId1.toHexString() })).save();
+        await new Area(createArea({ userId: USERS.USER.id, subscriptionId: subId1 })).save();
 
         const response = await requester.get(`/api/v2/area?loggedUser=${JSON.stringify(USERS.USER)}`);
         response.status.should.equal(200);
@@ -87,9 +87,9 @@ describe('V2 - Get areas', () => {
         // eslint-disable-next-line no-unused-expressions
         response.body.data.find((element) => element.id === area.id).should.be.ok;
         // eslint-disable-next-line no-unused-expressions
-        response.body.data.find((element) => element.attributes.subscriptionId === subId1.toHexString()).should.be.ok;
+        response.body.data.find((element) => element.attributes.subscriptionId === subId1).should.be.ok;
         // eslint-disable-next-line no-unused-expressions
-        response.body.data.find((element) => element.attributes.subscriptionId === subId2.toHexString()).should.be.ok;
+        response.body.data.find((element) => element.attributes.subscriptionId === subId2).should.be.ok;
     });
 
     it('Getting areas sending query param all as an USER/MANAGER should return a 200 OK with only the user areas (query filter is ignored)', async () => {
@@ -116,20 +116,17 @@ describe('V2 - Get areas', () => {
     });
 
     it('Getting areas sending query param all as an ADMIN should return a 200 OK with all the areas (even not owned by the user)', async () => {
-        const subId1 = new mongoose.Types.ObjectId();
-        const subId2 = new mongoose.Types.ObjectId();
-        const subId3 = new mongoose.Types.ObjectId();
+        const subId1 = new mongoose.Types.ObjectId().toString();
+        const subId2 = new mongoose.Types.ObjectId().toString();
+        const subId3 = new mongoose.Types.ObjectId().toString();
 
         const area1 = await new Area(createArea({ userId: USERS.USER.id })).save();
         const area2 = await new Area(createArea({ userId: USERS.MANAGER.id })).save();
-        const area3 = await new Area(createArea({
-            userId: USERS.ADMIN.id,
-            subscriptionId: subId1.toHexString()
-        })).save();
+        const area3 = await new Area(createArea({ userId: USERS.ADMIN.id, subscriptionId: subId1 })).save();
 
         // Mock three subscriptions
         mockSubscriptionFindAll(
-            [subId1.toHexString(), subId2.toHexString(), subId3.toHexString()],
+            [subId1, subId2, subId3],
             [{ userId: USERS.USER.id }, { userId: USERS.MANAGER.id }, { userId: USERS.ADMIN.id }]
         );
 
@@ -140,16 +137,16 @@ describe('V2 - Get areas', () => {
         response.body.data.should.have.property('syncedAreas').and.equal(1);
         response.body.data.should.have.property('createdAreas').and.equal(2);
 
-        mockSubscriptionFindByIds([subId1.toString()], { userId: USERS.USER.id });
-        mockSubscriptionFindByIds([subId2.toString()], { userId: USERS.USER.id });
-        mockSubscriptionFindByIds([subId3.toString()], { userId: USERS.USER.id });
+        mockSubscriptionFindByIds([subId1], { userId: USERS.USER.id });
+        mockSubscriptionFindByIds([subId2], { userId: USERS.USER.id });
+        mockSubscriptionFindByIds([subId3], { userId: USERS.USER.id });
 
         // Get all areas
         const getResponse = await requester.get(`/api/v2/area?loggedUser=${JSON.stringify(USERS.ADMIN)}&all=true`);
         getResponse.status.should.equal(200);
         getResponse.body.should.have.property('data').and.be.an('array').and.have.length(5);
         getResponse.body.data.map((area) => area.id).should.include.members([area1.id, area2.id, area3.id]);
-        getResponse.body.data.map((area) => area.attributes.subscriptionId).should.include.members([subId1.toHexString(), subId2.toHexString(), subId3.toHexString()]);
+        getResponse.body.data.map((area) => area.attributes.subscriptionId).should.include.members([subId1, subId2, subId3]);
     });
 
     it('Getting areas filtered by application should return a 200 OK with only areas for the application requested', async () => {

--- a/app/test/e2e/v2/get-area.spec.js
+++ b/app/test/e2e/v2/get-area.spec.js
@@ -52,12 +52,12 @@ describe('V2 - Get areas', () => {
     });
 
     it('Getting areas having some subscriptions should return a 200 OK with all the areas and subscriptions for the current user', async () => {
-        const id1 = new mongoose.Types.ObjectId();
-        const id2 = new mongoose.Types.ObjectId();
+        const id1 = new mongoose.Types.ObjectId().toString();
+        const id2 = new mongoose.Types.ObjectId().toString();
 
-        mockSubscriptionFindForUser(USERS.USER.id, [id1.toString(), id2.toString()]);
-        mockSubscriptionFindByIds([id1.toString()], { userId: USERS.USER.id });
-        mockSubscriptionFindByIds([id2.toString()], { userId: USERS.USER.id });
+        mockSubscriptionFindForUser(USERS.USER.id, [id1, id2]);
+        mockSubscriptionFindByIds([id1], { userId: USERS.USER.id });
+        mockSubscriptionFindByIds([id2], { userId: USERS.USER.id });
 
         const createdArea = await new Area(createArea({ userId: USERS.USER.id })).save();
         const response = await requester.get(`/api/v2/area?loggedUser=${JSON.stringify(USERS.USER)}`);
@@ -65,8 +65,8 @@ describe('V2 - Get areas', () => {
         response.body.should.have.property('data').and.be.an('array').and.have.length(3);
 
         response.body.data.find((area) => area.id === createdArea.id).should.be.an('object');
-        response.body.data.find((area) => area.id === id1.toString()).should.be.an('object');
-        response.body.data.find((area) => area.id === id2.toString()).should.be.an('object');
+        response.body.data.find((area) => area.id === id1).should.be.an('object');
+        response.body.data.find((area) => area.id === id2).should.be.an('object');
     });
 
     it('Getting areas having some subscriptions related to areas should return a 200 OK with all the areas and subscriptions for the current user', async () => {

--- a/app/test/e2e/v2/get-single-area.spec.js
+++ b/app/test/e2e/v2/get-single-area.spec.js
@@ -54,26 +54,26 @@ describe('V2 - Get single area', () => {
     });
 
     it('Getting an area that does not exist in the areas database, but corresponds to an user subscription returns 200 OK with the subscription info', async () => {
-        const id = new mongoose.Types.ObjectId();
+        const id = new mongoose.Types.ObjectId().toString();
         mockSubscriptionFindByIds([id], { userId: USERS.USER.id }, 2);
         const response = await requester.get(`/api/v2/area/${id}?loggedUser=${JSON.stringify(USERS.USER)}`);
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('object');
         response.body.data.should.have.property('attributes').and.be.an('object');
-        response.body.data.attributes.should.have.property('subscriptionId').and.equal(id.toHexString());
+        response.body.data.attributes.should.have.property('subscriptionId').and.equal(id);
         response.body.data.attributes.should.have.property('confirmed').and.equal(true);
     });
 
     it('Getting an area which has an associated subscription returns 200 OK with the correct area info', async () => {
-        const id = new mongoose.Types.ObjectId();
+        const id = new mongoose.Types.ObjectId().toString();
         const area = await new Area(createArea({
             public: false,
             userId: USERS.USER.id,
-            subscriptionId: id.toHexString(),
+            subscriptionId: id,
             name: 'Area name',
         })).save();
 
-        mockSubscriptionFindByIds([id.toHexString()], {
+        mockSubscriptionFindByIds([id], {
             userId: USERS.USER.id,
             name: 'Subscription name',
             confirmed: false,

--- a/app/test/e2e/v2/get-single-area.spec.js
+++ b/app/test/e2e/v2/get-single-area.spec.js
@@ -55,7 +55,7 @@ describe('V2 - Get single area', () => {
 
     it('Getting an area that does not exist in the areas database, but corresponds to an user subscription returns 200 OK with the subscription info', async () => {
         const id = new mongoose.Types.ObjectId();
-        mockSubscriptionFindByIds([id], { userId: USERS.USER.id });
+        mockSubscriptionFindByIds([id], { userId: USERS.USER.id }, 2);
         const response = await requester.get(`/api/v2/area/${id}?loggedUser=${JSON.stringify(USERS.USER)}`);
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('object');
@@ -77,7 +77,7 @@ describe('V2 - Get single area', () => {
             userId: USERS.USER.id,
             name: 'Subscription name',
             confirmed: false,
-        });
+        }, 2);
 
         const response = await requester.get(`/api/v2/area/${area.id}?loggedUser=${JSON.stringify(USERS.USER)}`);
         response.status.should.equal(200);

--- a/app/test/e2e/v2/sync-areas.spec.js
+++ b/app/test/e2e/v2/sync-areas.spec.js
@@ -41,16 +41,16 @@ describe('V2 - Sync areas', () => {
     });
 
     it('Sync areas as an ADMIN updates the areas in the database with overwrite information from associated subscriptions, returning the number of synced areas', async () => {
-        const subId1 = new mongoose.Types.ObjectId();
-        const subId2 = new mongoose.Types.ObjectId();
-        const subId3 = new mongoose.Types.ObjectId();
+        const subId1 = new mongoose.Types.ObjectId().toString();
+        const subId2 = new mongoose.Types.ObjectId().toString();
+        const subId3 = new mongoose.Types.ObjectId().toString();
 
-        const area1 = await new Area(createArea({ subscriptionId: subId1.toHexString(), name: 'Old Name 1' })).save();
-        const area2 = await new Area(createArea({ subscriptionId: subId2.toHexString(), name: 'Old Name 2' })).save();
-        const area3 = await new Area(createArea({ subscriptionId: subId3.toHexString(), name: 'Old Name 3' })).save();
+        const area1 = await new Area(createArea({ subscriptionId: subId1, name: 'Old Name 1' })).save();
+        const area2 = await new Area(createArea({ subscriptionId: subId2, name: 'Old Name 2' })).save();
+        const area3 = await new Area(createArea({ subscriptionId: subId3, name: 'Old Name 3' })).save();
 
         mockSubscriptionFindAll(
-            [subId1.toHexString(), subId2.toHexString(), subId3.toHexString()],
+            [subId1, subId2, subId3],
             [{ name: 'Updated subscription 1' }, { name: 'Updated subscription 2' }, { name: 'Updated subscription 3' }]
         );
 
@@ -106,12 +106,12 @@ describe('V2 - Sync areas', () => {
     });
 
     it('Failures syncing areas do not block a successful response', async () => {
-        const subId = new mongoose.Types.ObjectId();
-        await new Area(createArea({ subscriptionId: subId.toHexString(), name: 'Old Name 1' })).save();
+        const subId = new mongoose.Types.ObjectId().toString();
+        await new Area(createArea({ subscriptionId: subId, name: 'Old Name 1' })).save();
 
         // Return a subscription that will provoke an error when saving
         mockSubscriptionFindAll(
-            [subId.toHexString()],
+            [subId],
             [{
                 name: 'Updated subscription 1',
                 params: {

--- a/app/test/e2e/v2/update-area.spec.js
+++ b/app/test/e2e/v2/update-area.spec.js
@@ -159,6 +159,7 @@ describe('V2 - Update area', () => {
         testArea.should.have.property('subscriptionId').and.equal('');
 
         mockSubscriptionCreation('5e3bf82fad36f4001abe150e');
+        mockSubscriptionFindByIds(['5e3bf82fad36f4001abe150e'], { userId: USERS.USER.id });
 
         const response = await requester
             .patch(`/api/v2/area/${testArea.id}`)
@@ -180,6 +181,7 @@ describe('V2 - Update area', () => {
         testArea.should.have.property('subscriptionId').and.equal('5e3bf82fad36f4001abe1444');
 
         mockSubscriptionEdition('5e3bf82fad36f4001abe1444');
+        mockSubscriptionFindByIds(['5e3bf82fad36f4001abe1444'], { userId: USERS.USER.id });
 
         const response = await requester
             .patch(`/api/v2/area/${testArea.id}`)
@@ -234,6 +236,7 @@ describe('V2 - Update area', () => {
     it('Updating an area that didn\'t exist (existing subscription) creates a new area and PATCHes subscription, returning a 200 HTTP code and the updated area object', async () => {
         mockSubscriptionFindByIds(['5e3bf82fad36f4001abe1333']);
         mockSubscriptionEdition('5e3bf82fad36f4001abe1333');
+        mockSubscriptionFindByIds(['5e3bf82fad36f4001abe1333'], { userId: USERS.USER.id });
 
         const response = await requester
             .patch(`/api/v2/area/5e3bf82fad36f4001abe1333`)


### PR DESCRIPTION
This PR adds the subscription field `confirmed` to all endpoints of the Areas service. This field will default to `false`, and it will take the value `true` iff the subscription associated with the area is confirmed.