### PR TITLE
Feat/geostore saved check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.6.1
+
+## 20/07/2020
+
+- Adjust automatic `status` update behavior and tests for it.
+
 # v1.6.0
 
 ## 13/07/2020

--- a/app/src/routes/api/v2/area.router.js
+++ b/app/src/routes/api/v2/area.router.js
@@ -347,6 +347,10 @@ class AreaRouterV2 {
             const savedAreas = await AreaModel.find(query);
             if (savedAreas && savedAreas.length > 0) isSaved = true;
             area.geostore = ctx.request.body.geostore;
+
+            // Update status to saved if geostore already exists with status=saved
+            area.status = isSaved ? 'saved' : 'pending';
+            logger.info(`Updating area with id ${ctx.params.id} to status ${isSaved ? 'saved' : 'pending'}`);
         }
         if (ctx.request.body.wdpaid) {
             area.wdpaid = ctx.request.body.wdpaid;
@@ -376,17 +380,8 @@ class AreaRouterV2 {
         if (ctx.request.body.tags) {
             area.tags = ctx.request.body.tags;
         }
-        // Update status to saved if geostore already exists with status=saved
-        if (ctx.request.body.status || isSaved) {
-            const status = isSaved ? 'saved' : ctx.request.body.status;
-            logger.info(`Updating area with id ${ctx.params.id} to status ${status}`);
-            area.status = status;
-        }
         if (ctx.request.body.public) {
             area.public = ctx.request.body.public;
-        }
-        if (ctx.request.body.status) {
-            area.status = ctx.request.body.status;
         }
         const updateKeys = ctx.request.body && Object.keys(ctx.request.body);
         area.public = updateKeys.includes('public') ? ctx.request.body.public : area.public;

--- a/app/src/routes/api/v2/area.router.js
+++ b/app/src/routes/api/v2/area.router.js
@@ -392,7 +392,7 @@ class AreaRouterV2 {
         area.subscriptionId = updateKeys.includes('subscriptionId') ? ctx.request.body.subscriptionId : area.subscriptionId;
         area.email = updateKeys.includes('email') ? ctx.request.body.email : area.email;
         area.language = updateKeys.includes('language') ? ctx.request.body.language : area.language;
-        area.status = updateKeys.includes('status') ? ctx.request.body.status : area.status;
+        area.status = updateKeys.includes('status') && ctx.state.loggedUser.role === 'ADMIN' ? ctx.request.body.status : area.status;
         if (files && files.image) {
             area.image = await s3Service.uploadFile(files.image.path, files.image.name);
         }


### PR DESCRIPTION
When an update or sync results in a change in geostore id, checks the database for any record with that geostore having status=saved.

If one exists, also updates that areas status to  `saved`.