### PR TITLE
Update local docker setup so it builds and registers with the Control Tower correctly

### DIFF
--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -6,7 +6,7 @@ services:
       - "4200:4100"
     container_name: gfw-area
     env_file:
-      - dev.env.sample
+      - dev.env
     environment:
       PORT: 4100
       NODE_ENV: dev


### PR DESCRIPTION
I have made a series of small changes which ensures that the microservices build and register with the Control Tower locally with Docker.

The changes to this repo are:
- load `dev.env`, not `dev.env.sample` in docker compose