### PR TITLE
Add support for different GLAD alert types for v2 areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,13 @@
-## 09/06/2021
+# v1.8.0
 
+## 29/09/2021
+
+- Add support for different GLAD alert types for a v2 area
 - Add support for hosts from `x-rw-domain` header when generating pagination links.
-
-## 31/05/2021
-
 - Update `rw-api-microservice-node` to add CORS support.
-
-## 21/05/2021
-
 - Add support for hosts from `referer` header when generating pagination links.
-
-## 20/05/2021
-
 - Improve error message when updating geostore with invalid application values.
-
-## 12/02/2021
-
 - Remove dependency on CT's `authenticated` functionality
-
-## 29/01/2021
-
 - Replace CT integration library
 
 # v1.7.1

--- a/app/src/models/area.modelV2.js
+++ b/app/src/models/area.modelV2.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const mongoosePaginate = require('mongoose-paginate');
 const mongooseHistory = require('mongoose-history');
+const gladAlertTypes = require('models/glad-alert-types');
 
 const { Schema } = mongoose;
 
@@ -62,6 +63,9 @@ const Area = new Schema({
     },
     deforestationAlerts: {
         type: Boolean, trim: true, required: true, default: false
+    },
+    deforestationAlertsType: {
+        type: String, enum: Object.values(gladAlertTypes), trim: true, required: false
     },
     webhookUrl: {
         type: String, trim: true, required: false, default: ''

--- a/app/src/models/glad-alert-types.js
+++ b/app/src/models/glad-alert-types.js
@@ -1,0 +1,6 @@
+module.exports = Object.freeze({
+    GLAD_ALL: 'glad-all',
+    GLAD_L: 'glad-l',
+    GLAD_S2: 'glad-s2',
+    GLAD_RADD: 'glad-radd'
+});

--- a/app/src/serializers/area.serializerV2.js
+++ b/app/src/serializers/area.serializerV2.js
@@ -22,6 +22,7 @@ const areaSerializer = new JSONAPISerializer('area', {
         'public',
         'fireAlerts',
         'deforestationAlerts',
+        'deforestationAlertsType',
         'webhookUrl',
         'monthlySummary',
         'subscriptionId',

--- a/app/src/services/subscription.service.js
+++ b/app/src/services/subscription.service.js
@@ -148,7 +148,9 @@ class SubscriptionsService {
 
     static getDatasetsForSubscription(area) {
         const datasets = [];
-        if (area.deforestationAlerts) datasets.push(config.get('datasets.deforestation'));
+        if (area.deforestationAlerts) {
+            datasets.push(area.deforestationAlertsType || config.get('datasets.deforestation'));
+        }
         if (area.fireAlerts) datasets.push(config.get('datasets.fires'));
         if (area.monthlySummary) datasets.push(config.get('datasets.monthlySummary'));
         return datasets;

--- a/app/test/e2e/utils/helpers.js
+++ b/app/test/e2e/utils/helpers.js
@@ -29,9 +29,9 @@ const getDefaultSubscription = (override = {}) => ({
     ...override
 });
 
-const mockSubscriptionCreation = (id = '123', override = {}) => {
+const mockSubscriptionCreation = (id = '123', override = {}, validator = () => true) => {
     nock(process.env.CT_URL)
-        .post(`/v1/subscriptions`)
+        .post(`/v1/subscriptions`, validator)
         .reply(200, () => ({
             data: {
                 type: 'subscription',

--- a/config/default.json
+++ b/config/default.json
@@ -32,8 +32,8 @@
     "flagshipUrl": "https://staging.globalforestwatch.org/"
   },
   "datasets": {
-    "deforestation": "deforestation_alerts_dataset_id",
-    "fires": "fire_alerts_dataset_id",
-    "monthlySummary": "monthly_summary_dataset_id"
+    "deforestation": "glad-alerts",
+    "fires": "viirs-active-fires",
+    "monthlySummary": "monthly-summary"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gfw-areas",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Area of Interest service for the RW API.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR adds support for different GLAD alert types for v2 areas. This can be achieved by providing `deforestationAlerts` as `true` and `deforestationAlertsType` with the corresponding selected type in the request body when creating or editing areas of interest - example:

```json
{
  "deforestationAlerts": true,
  "deforestationAlertsType": "glad-s2"
}
```

The supported values for the GLAD alert types are: `glad-all`, `glad-l`, `glad-s2` or `glad-radd`.