### PR TITLE
tests: adds missing tests for deleteAreasByUserId endpoints v1 and v2

### DIFF
--- a/app/test/e2e/v1/delete-areas.spec.js
+++ b/app/test/e2e/v1/delete-areas.spec.js
@@ -106,6 +106,64 @@ describe('V1 - Delete areas by user id tests', () => {
         areaNames.should.contain(fakeAreaFromAdmin.name);
     });
 
+    it('Deleting all areas of an user while being authenticated as a microservice should return a 200 and all widgets deleted', async () => {
+        mockGetUserFromToken(USERS.MICROSERVICE);
+
+        const teamId = getUUID();
+        const areaOne = await new Area(createArea({ env: 'staging', userId: USERS.USER.id })).save();
+        const areaTwo = await new Area(createArea({ env: 'production', userId: USERS.USER.id })).save();
+        const fakeAreaFromAdmin = await new Area(createArea({ env: 'production', userId: USERS.ADMIN.id })).save();
+        const fakeAreaFromManager = await new Area(createArea({ env: 'staging', userId: USERS.MANAGER.id })).save();
+
+        nock(process.env.GATEWAY_URL)
+            .get(`/v1/teams/user/${USERS.USER.id}`)
+            .times(2)
+            .reply(200, {
+                data: {
+                    id: teamId,
+                    attributes: {
+                        areas: [areaOne._id.toString()]
+                    }
+                }
+            });
+
+        nock(process.env.GATEWAY_URL)
+            .patch(`/v1/teams/${teamId}`, {
+                areas: []
+            })
+            .reply(200, {
+                data: {
+                    id: teamId,
+                    attributes: {
+                        areas: [areaOne._id.toString()]
+                    }
+                }
+            });
+
+        const response = await requester
+            .delete(`/api/v1/area/by-user/${USERS.USER.id}`)
+            .set('Authorization', 'Bearer abcd')
+            .send();
+
+        response.status.should.equal(200);
+        response.body.data[0].id.should.equal(areaOne._id.toString());
+        response.body.data[0].attributes.name.should.equal(areaOne.name);
+        response.body.data[0].attributes.userId.should.equal(areaOne.userId);
+        response.body.data[1].id.should.equal(areaTwo._id.toString());
+        response.body.data[1].attributes.name.should.equal(areaTwo.name);
+        response.body.data[1].attributes.userId.should.equal(areaTwo.userId);
+
+        const findAreaByUser = await Area.find({ userId: { $eq: USERS.USER.id } }).exec();
+        findAreaByUser.should.be.an('array').with.lengthOf(0);
+
+        const findAllAreas = await Area.find({}).exec();
+        findAllAreas.should.be.an('array').with.lengthOf(2);
+
+        const areaNames = findAllAreas.map((area) => area.name);
+        areaNames.should.contain(fakeAreaFromManager.name);
+        areaNames.should.contain(fakeAreaFromAdmin.name);
+    });
+
     it('Deleting all areas of an user while being authenticated as USER should return a 200 and all widgets deleted', async () => {
         mockGetUserFromToken(USERS.USER);
 
@@ -170,6 +228,18 @@ describe('V1 - Delete areas by user id tests', () => {
         const areaNames = findAllAreas.map((area) => area.name);
         areaNames.should.contain(fakeAreaFromManager.name);
         areaNames.should.contain(fakeAreaFromAdmin.name);
+    });
+
+    it('Deleting all areas of an user while being authenticated as USER should return a 200 and all areas deleted - no areas in the db', async () => {
+        mockGetUserFromToken(USERS.USER);
+
+        const response = await requester
+            .delete(`/api/v1/area/by-user/${USERS.USER.id}`)
+            .set('Authorization', 'Bearer abcd')
+            .send();
+
+        response.status.should.equal(200);
+        response.body.data.should.be.an('array').with.lengthOf(0);
     });
 
     afterEach(async () => {


### PR DESCRIPTION
-Adds tests for microservice user in deleteByUserId endpoints both in area v1 and v2.
-Add missing test for same endpoint where there are no entities from the user. (It should return an empty array).