### PR TITLE
GTC-3085: Add Admin Version to Area Representation

### DIFF
--- a/app/src/serializers/adminSourceUtils.js
+++ b/app/src/serializers/adminSourceUtils.js
@@ -10,21 +10,25 @@ function isAdministrativeBoundary(area) {
 }
 
 function addSource(adminInfo) {
-    adminInfo.source = {
-        provider: 'gadm',
-        version: gadmVersion,
+    const result = {
+        ...adminInfo,
+        source: {
+            provider: 'gadm',
+            version: gadmVersion,
+        }
     };
+    return result;
 }
 
 function addSourceToIsoAttribute(area) {
     if (area.attributes ? area.attributes.iso : null) {
-        addSource(area.attributes.iso);
+        area.attributes.iso = addSource(area.attributes.iso);
     }
 }
 
 function addSourceToAdminAttribute(area) {
     if (area.attributes ? area.attributes.admin : null) {
-        addSource(area.attributes.admin);
+        area.attributes.admin = addSource(area.attributes.admin);
     }
 }
 
@@ -37,13 +41,17 @@ function addSourceForAdministrativeAreas(data) {
 }
 
 const addV1SourceForAdministrativeAreas = (data) => {
+    const plainObject = JSON.parse(JSON.stringify(data));
     gadmVersion = GADM_VERSION_2_8;
-    addSourceForAdministrativeAreas(data);
+    addSourceForAdministrativeAreas(plainObject);
+    return plainObject;
 };
 
 const addV2SourceForAdministrativeAreas = (data) => {
+    const plainObject = JSON.parse(JSON.stringify(data));
     gadmVersion = GADM_VERSION_3_6;
-    addSourceForAdministrativeAreas(data);
+    addSourceForAdministrativeAreas(plainObject);
+    return plainObject;
 };
 
 module.exports = { addV1SourceForAdministrativeAreas, addV2SourceForAdministrativeAreas };

--- a/app/src/serializers/adminSourceUtils.js
+++ b/app/src/serializers/adminSourceUtils.js
@@ -1,0 +1,54 @@
+const GADM_VERSION_2_8 = '2.8';
+const GADM_VERSION_3_6 = '3.6';
+
+let gadmVersion = GADM_VERSION_2_8;
+
+function isAdministrativeBoundary(area) {
+    if (area.attributes && area.attributes.iso && area.attributes.iso.country) {
+        return !!area.attributes.iso.country;
+    }
+
+    return area.attributes && area.attributes.admin
+        ? !!area.attributes.admin.adm0
+        : false;
+
+}
+
+function addSource(adminInfo) {
+    adminInfo.source = {
+        provider: 'gadm',
+        version: gadmVersion,
+    };
+}
+
+function addSourceToIsoAttribute(area) {
+    if (area.attributes ? area.attributes.iso : null) {
+        addSource(area.attributes.iso);
+    }
+}
+
+function addSourceToAdminAttribute(area) {
+    if (area.attributes ? area.attributes.admin : null) {
+        addSource(area.attributes.admin);
+    }
+}
+
+function addSourceForAdministrativeAreas(data) {
+    const areas = Array.isArray(data) ? data : [data];
+    areas.filter(isAdministrativeBoundary).forEach((area) => {
+        addSourceToIsoAttribute(area);
+        addSourceToAdminAttribute(area);
+    });
+}
+
+const addV1SourceForAdministrativeAreas = (data) => {
+    gadmVersion = GADM_VERSION_2_8;
+    addSourceForAdministrativeAreas(data);
+};
+
+const addV2SourceForAdministrativeAreas = (data) => {
+    gadmVersion = GADM_VERSION_3_6;
+    addSourceForAdministrativeAreas(data);
+};
+
+module.exports = { addV1SourceForAdministrativeAreas, addV2SourceForAdministrativeAreas };

--- a/app/src/serializers/adminSourceUtils.js
+++ b/app/src/serializers/adminSourceUtils.js
@@ -3,10 +3,16 @@ const GADM_VERSION_3_6 = '3.6';
 
 let gadmVersion = GADM_VERSION_2_8;
 
+function isIsoDefined(area) {
+    return area.attributes.iso && area.attributes.iso.country;
+}
+
+function isAdminDefined(area) {
+    return area.attributes.admin && area.attributes.admin.adm0;
+}
+
 function isAdministrativeBoundary(area) {
-    const iso = area.attributes ? area.attributes.iso : null;
-    const admin = area.attributes ? area.attributes.admin : null;
-    return (iso && iso.country) || (admin && admin.adm0);
+    return isIsoDefined(area) || isAdminDefined(area);
 }
 
 function addSource(adminInfo) {
@@ -21,13 +27,13 @@ function addSource(adminInfo) {
 }
 
 function addSourceToIsoAttribute(area) {
-    if (area.attributes ? area.attributes.iso : null) {
+    if (isIsoDefined(area)) {
         area.attributes.iso = addSource(area.attributes.iso);
     }
 }
 
 function addSourceToAdminAttribute(area) {
-    if (area.attributes ? area.attributes.admin : null) {
+    if (isAdminDefined(area)) {
         area.attributes.admin = addSource(area.attributes.admin);
     }
 }

--- a/app/src/serializers/adminSourceUtils.js
+++ b/app/src/serializers/adminSourceUtils.js
@@ -44,20 +44,17 @@ function addSourceForAdministrativeAreas(data) {
         addSourceToIsoAttribute(area);
         addSourceToAdminAttribute(area);
     });
+    return data;
 }
 
 const addV1SourceForAdministrativeAreas = (data) => {
-    const plainObject = JSON.parse(JSON.stringify(data));
     gadmVersion = GADM_VERSION_2_8;
-    addSourceForAdministrativeAreas(plainObject);
-    return plainObject;
+    return addSourceForAdministrativeAreas(data);
 };
 
 const addV2SourceForAdministrativeAreas = (data) => {
-    const plainObject = JSON.parse(JSON.stringify(data));
     gadmVersion = GADM_VERSION_3_6;
-    addSourceForAdministrativeAreas(plainObject);
-    return plainObject;
+    return addSourceForAdministrativeAreas(data);
 };
 
 module.exports = { addV1SourceForAdministrativeAreas, addV2SourceForAdministrativeAreas };

--- a/app/src/serializers/adminSourceUtils.js
+++ b/app/src/serializers/adminSourceUtils.js
@@ -4,14 +4,9 @@ const GADM_VERSION_3_6 = '3.6';
 let gadmVersion = GADM_VERSION_2_8;
 
 function isAdministrativeBoundary(area) {
-    if (area.attributes && area.attributes.iso && area.attributes.iso.country) {
-        return !!area.attributes.iso.country;
-    }
-
-    return area.attributes && area.attributes.admin
-        ? !!area.attributes.admin.adm0
-        : false;
-
+    const iso = area.attributes ? area.attributes.iso : null;
+    const admin = area.attributes ? area.attributes.admin : null;
+    return (iso && iso.country) || (admin && admin.adm0);
 }
 
 function addSource(adminInfo) {

--- a/app/src/serializers/area.serializer.js
+++ b/app/src/serializers/area.serializer.js
@@ -25,6 +25,44 @@ const areaSerializer = new JSONAPISerializer('area', {
     keyForAttribute: 'camelCase'
 });
 
+function isAdministrativeBoundary(area) {
+    if (area.attributes && area.attributes.iso && area.attributes.iso.country) {
+        return !!area.attributes.iso.country;
+    }
+
+    return area.attributes && area.attributes.admin
+        ? !!area.attributes.admin.adm0
+        : false;
+
+}
+
+function addSource(adminInfo) {
+    adminInfo.source = {
+        provider: 'gadm',
+        version: '2.8',
+    };
+}
+
+function addSourceToIsoAttribute(area) {
+    if (area.attributes ? area.attributes.iso : null) {
+        addSource(area.attributes.iso);
+    }
+}
+
+function addSourceToAdminAttribute(area) {
+    if (area.attributes ? area.attributes.admin : null) {
+        addSource(area.attributes.admin);
+    }
+}
+
+const addSourceForAdministrativeAreas = (data) => {
+    const areas = Array.isArray(data) ? data : [data];
+    areas.filter(isAdministrativeBoundary).forEach((area) => {
+        addSourceToIsoAttribute(area);
+        addSourceToAdminAttribute(area);
+    });
+};
+
 class AreaSerializer {
 
     static serialize(data, link = null) {
@@ -34,6 +72,8 @@ class AreaSerializer {
         } else {
             result = areaSerializer.serialize(data);
         }
+
+        addSourceForAdministrativeAreas(result.data);
 
         if (link) {
             result.links = {

--- a/app/src/serializers/area.serializer.js
+++ b/app/src/serializers/area.serializer.js
@@ -36,7 +36,7 @@ class AreaSerializer {
             result = areaSerializer.serialize(data);
         }
 
-        addV1SourceForAdministrativeAreas(result.data);
+        result.data = addV1SourceForAdministrativeAreas(result.data);
 
         if (link) {
             result.links = {

--- a/app/src/serializers/area.serializer.js
+++ b/app/src/serializers/area.serializer.js
@@ -1,4 +1,5 @@
 const JSONAPISerializer = require('jsonapi-serializer').Serializer;
+const { addV1SourceForAdministrativeAreas } = require('./adminSourceUtils');
 
 const areaSerializer = new JSONAPISerializer('area', {
     attributes: [
@@ -25,44 +26,6 @@ const areaSerializer = new JSONAPISerializer('area', {
     keyForAttribute: 'camelCase'
 });
 
-function isAdministrativeBoundary(area) {
-    if (area.attributes && area.attributes.iso && area.attributes.iso.country) {
-        return !!area.attributes.iso.country;
-    }
-
-    return area.attributes && area.attributes.admin
-        ? !!area.attributes.admin.adm0
-        : false;
-
-}
-
-function addSource(adminInfo) {
-    adminInfo.source = {
-        provider: 'gadm',
-        version: '2.8',
-    };
-}
-
-function addSourceToIsoAttribute(area) {
-    if (area.attributes ? area.attributes.iso : null) {
-        addSource(area.attributes.iso);
-    }
-}
-
-function addSourceToAdminAttribute(area) {
-    if (area.attributes ? area.attributes.admin : null) {
-        addSource(area.attributes.admin);
-    }
-}
-
-const addSourceForAdministrativeAreas = (data) => {
-    const areas = Array.isArray(data) ? data : [data];
-    areas.filter(isAdministrativeBoundary).forEach((area) => {
-        addSourceToIsoAttribute(area);
-        addSourceToAdminAttribute(area);
-    });
-};
-
 class AreaSerializer {
 
     static serialize(data, link = null) {
@@ -73,7 +36,7 @@ class AreaSerializer {
             result = areaSerializer.serialize(data);
         }
 
-        addSourceForAdministrativeAreas(result.data);
+        addV1SourceForAdministrativeAreas(result.data);
 
         if (link) {
             result.links = {
@@ -91,7 +54,6 @@ class AreaSerializer {
         }
         return result;
     }
-
 
 }
 

--- a/app/src/serializers/area.serializer.js
+++ b/app/src/serializers/area.serializer.js
@@ -36,7 +36,7 @@ class AreaSerializer {
             result = areaSerializer.serialize(data);
         }
 
-        result.data = addV1SourceForAdministrativeAreas(result.data);
+        result.data = addV1SourceForAdministrativeAreas(JSON.parse(JSON.stringify(result.data)));
 
         if (link) {
             result.links = {

--- a/app/src/serializers/area.serializerV2.js
+++ b/app/src/serializers/area.serializerV2.js
@@ -54,7 +54,7 @@ class AreaSerializer {
             });
         }
 
-        serializedData.data = addV2SourceForAdministrativeAreas(serializedData.data);
+        serializedData.data = addV2SourceForAdministrativeAreas(JSON.parse(JSON.stringify(serializedData.data)));
 
         if (link) {
             serializedData.links = {

--- a/app/src/serializers/area.serializerV2.js
+++ b/app/src/serializers/area.serializerV2.js
@@ -1,4 +1,5 @@
 const JSONAPISerializer = require('jsonapi-serializer').Serializer;
+const { addV2SourceForAdministrativeAreas } = require('./adminSourceUtils');
 
 const areaSerializer = new JSONAPISerializer('area', {
     attributes: [
@@ -39,44 +40,6 @@ const areaSerializer = new JSONAPISerializer('area', {
     keyForAttribute: 'camelCase'
 });
 
-function isAdministrativeBoundary(area) {
-    if (area.attributes && area.attributes.iso && area.attributes.iso.country) {
-        return !!area.attributes.iso.country;
-    }
-
-    return area.attributes && area.attributes.admin
-        ? !!area.attributes.admin.adm0
-        : false;
-
-}
-
-function addSource(adminInfo) {
-    adminInfo.source = {
-        provider: 'gadm',
-        version: '3.6',
-    };
-}
-
-function addSourceToIsoAttribute(area) {
-    if (area.attributes ? area.attributes.iso : null) {
-        addSource(area.attributes.iso);
-    }
-}
-
-function addSourceToAdminAttribute(area) {
-    if (area.attributes ? area.attributes.admin : null) {
-        addSource(area.attributes.admin);
-    }
-}
-
-const addSourceForAdministrativeAreas = (data) => {
-    const areas = Array.isArray(data) ? data : [data];
-    areas.filter(isAdministrativeBoundary).forEach((area) => {
-        addSourceToIsoAttribute(area);
-        addSourceToAdminAttribute(area);
-    });
-};
-
 class AreaSerializer {
 
     static serialize(data, link = null) {
@@ -91,7 +54,7 @@ class AreaSerializer {
             });
         }
 
-        addSourceForAdministrativeAreas(serializedData.data);
+        addV2SourceForAdministrativeAreas(serializedData.data);
 
         if (link) {
             serializedData.links = {

--- a/app/src/serializers/area.serializerV2.js
+++ b/app/src/serializers/area.serializerV2.js
@@ -49,21 +49,22 @@ function isAdministrativeBoundary(area) {
 
 }
 
+function addSource(adminInfo) {
+    adminInfo.source = {
+        provider: 'gadm',
+        version: '3.6',
+    };
+}
+
 function addSourceToIsoAttribute(area) {
     if (area.attributes ? area.attributes.iso : undefined) {
-        area.attributes.iso.source = {
-            provider: 'gadm',
-            version: '3.6',
-        };
+        addSource(area.attributes.iso);
     }
 }
 
 function addSourceToAdminAttribute(area) {
     if (area.attributes ? area.attributes.admin : undefined) {
-        area.attributes.admin.source = {
-            provider: 'gadm',
-            version: '3.6',
-        };
+        addSource(area.attributes.admin);
     }
 }
 

--- a/app/src/serializers/area.serializerV2.js
+++ b/app/src/serializers/area.serializerV2.js
@@ -39,6 +39,42 @@ const areaSerializer = new JSONAPISerializer('area', {
     keyForAttribute: 'camelCase'
 });
 
+function isAdministrativeBoundary(area) {
+    if (area.attributes && area.attributes.iso && area.attributes.iso.country) {
+        return !!area.attributes.iso.country;
+    }
+    return area.attributes && area.attributes.admin
+        ? !!area.attributes.admin.adm0
+        : false;
+
+}
+
+function addSourceToIsoAttribute(area) {
+    if (area.attributes ? area.attributes.iso : undefined) {
+        area.attributes.iso.source = {
+            provider: 'gadm',
+            version: '3.6',
+        };
+    }
+}
+
+function addSourceToAdminAttribute(area) {
+    if (area.attributes ? area.attributes.admin : undefined) {
+        area.attributes.admin.source = {
+            provider: 'gadm',
+            version: '3.6',
+        };
+    }
+}
+
+const addSourceForAdministrativeAreas = (data) => {
+    const areas = Array.isArray(data) ? data : [data];
+    areas.filter(isAdministrativeBoundary).forEach((area) => {
+        addSourceToIsoAttribute(area);
+        addSourceToAdminAttribute(area);
+    });
+};
+
 class AreaSerializer {
 
     static serialize(data, link = null) {
@@ -52,6 +88,8 @@ class AreaSerializer {
                 }
             });
         }
+
+        addSourceForAdministrativeAreas(serializedData.data);
 
         if (link) {
             serializedData.links = {

--- a/app/src/serializers/area.serializerV2.js
+++ b/app/src/serializers/area.serializerV2.js
@@ -43,6 +43,7 @@ function isAdministrativeBoundary(area) {
     if (area.attributes && area.attributes.iso && area.attributes.iso.country) {
         return !!area.attributes.iso.country;
     }
+
     return area.attributes && area.attributes.admin
         ? !!area.attributes.admin.adm0
         : false;
@@ -57,13 +58,13 @@ function addSource(adminInfo) {
 }
 
 function addSourceToIsoAttribute(area) {
-    if (area.attributes ? area.attributes.iso : undefined) {
+    if (area.attributes ? area.attributes.iso : null) {
         addSource(area.attributes.iso);
     }
 }
 
 function addSourceToAdminAttribute(area) {
-    if (area.attributes ? area.attributes.admin : undefined) {
+    if (area.attributes ? area.attributes.admin : null) {
         addSource(area.attributes.admin);
     }
 }

--- a/app/src/serializers/area.serializerV2.js
+++ b/app/src/serializers/area.serializerV2.js
@@ -54,7 +54,7 @@ class AreaSerializer {
             });
         }
 
-        addV2SourceForAdministrativeAreas(serializedData.data);
+        serializedData.data = addV2SourceForAdministrativeAreas(serializedData.data);
 
         if (link) {
             serializedData.links = {

--- a/app/test/e2e/v1/create-area-fw.spec.js
+++ b/app/test/e2e/v1/create-area-fw.spec.js
@@ -81,7 +81,11 @@ describe('V1 - Create area FW', () => {
         });
         response.body.data.attributes.should.have.property('iso').and.deep.equal({
             country: 'createdCountryIso',
-            region: 'createdRegionIso'
+            region: 'createdRegionIso',
+            source: {
+                provider: 'gadm',
+                version: '2.8',
+            }
         });
         response.body.data.attributes.should.have.property('createdAt');
         response.body.data.attributes.should.have.property('updatedAt');
@@ -166,7 +170,11 @@ describe('V1 - Create area FW', () => {
         });
         response.body.data.attributes.should.have.property('iso').and.deep.equal({
             country: 'createdCountryIso',
-            region: 'createdRegionIso'
+            region: 'createdRegionIso',
+            source: {
+                provider: 'gadm',
+                version: '2.8',
+            }
         });
         response.body.data.attributes.should.have.property('createdAt');
         response.body.data.attributes.should.have.property('updatedAt');

--- a/app/test/e2e/v1/create-area.spec.js
+++ b/app/test/e2e/v1/create-area.spec.js
@@ -81,7 +81,11 @@ describe('V1 - Create area', () => {
         });
         response.body.data.attributes.should.have.property('iso').and.deep.equal({
             country: 'createdCountryIso',
-            region: 'createdRegionIso'
+            region: 'createdRegionIso',
+            source: {
+                provider: 'gadm',
+                version: '2.8',
+            }
         });
         response.body.data.attributes.should.have.property('createdAt');
         response.body.data.attributes.should.have.property('updatedAt');
@@ -137,7 +141,11 @@ describe('V1 - Create area', () => {
         });
         response.body.data.attributes.should.have.property('iso').and.deep.equal({
             country: 'createdCountryIso',
-            region: 'createdRegionIso'
+            region: 'createdRegionIso',
+            source: {
+                provider: 'gadm',
+                version: '2.8',
+            }
         });
         response.body.data.attributes.should.have.property('createdAt');
         response.body.data.attributes.should.have.property('updatedAt');
@@ -197,7 +205,11 @@ describe('V1 - Create area', () => {
             });
             response.body.data.attributes.should.have.property('iso').and.deep.equal({
                 country: 'createdCountryIso',
-                region: 'createdRegionIso'
+                region: 'createdRegionIso',
+                source: {
+                    provider: 'gadm',
+                    version: '2.8',
+                }
             });
             response.body.data.attributes.should.have.property('createdAt');
             response.body.data.attributes.should.have.property('updatedAt');
@@ -256,7 +268,11 @@ describe('V1 - Create area', () => {
             });
             response.body.data.attributes.should.have.property('iso').and.deep.equal({
                 country: 'createdCountryIso',
-                region: 'createdRegionIso'
+                region: 'createdRegionIso',
+                source: {
+                    provider: 'gadm',
+                    version: '2.8',
+                }
             });
             response.body.data.attributes.should.have.property('createdAt');
             response.body.data.attributes.should.have.property('updatedAt');
@@ -313,7 +329,11 @@ describe('V1 - Create area', () => {
             });
             response.body.data.attributes.should.have.property('iso').and.deep.equal({
                 country: 'createdCountryIso',
-                region: 'createdRegionIso'
+                region: 'createdRegionIso',
+                source: {
+                    provider: 'gadm',
+                    version: '2.8',
+                }
             });
             response.body.data.attributes.should.have.property('createdAt');
             response.body.data.attributes.should.have.property('updatedAt');

--- a/app/test/e2e/v1/update-area.spec.js
+++ b/app/test/e2e/v1/update-area.spec.js
@@ -97,7 +97,11 @@ describe('V1 - Update area', () => {
         });
         response.body.data.attributes.should.have.property('iso').and.deep.equal({
             country: 'updatedCountryIso',
-            region: 'updatedRegionIso'
+            region: 'updatedRegionIso',
+            source: {
+                provider: 'gadm',
+                version: '2.8',
+            }
         });
         response.body.data.attributes.should.have.property('createdAt');
         response.body.data.attributes.should.have.property('updatedAt');
@@ -156,7 +160,11 @@ describe('V1 - Update area', () => {
         });
         response.body.data.attributes.should.have.property('iso').and.deep.equal({
             country: 'updatedCountryIso',
-            region: 'updatedRegionIso'
+            region: 'updatedRegionIso',
+            source: {
+                provider: 'gadm',
+                version: '2.8',
+            }
         });
         response.body.data.attributes.should.have.property('createdAt');
         response.body.data.attributes.should.have.property('updatedAt');
@@ -219,7 +227,11 @@ describe('V1 - Update area', () => {
         });
         response.body.data.attributes.should.have.property('iso').and.deep.equal({
             country: 'updatedCountryIso',
-            region: 'updatedRegionIso'
+            region: 'updatedRegionIso',
+            source: {
+                provider: 'gadm',
+                version: '2.8',
+            }
         });
         response.body.data.attributes.should.have.property('createdAt');
         response.body.data.attributes.should.have.property('updatedAt');

--- a/app/test/e2e/v2/create-area.spec.js
+++ b/app/test/e2e/v2/create-area.spec.js
@@ -96,6 +96,60 @@ describe('V2 - Create area', () => {
         });
     });
 
+    it('Creating an area while being logged in as a user that owns the area and using admin instead of iso should return a 200 HTTP code and the created area object', async () => {
+        mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
+
+        const response = await requester
+            .post(`/api/v2/area`)
+            .set('Authorization', 'Bearer abcd')
+            .set('x-api-key', 'api-key-test')
+            .send({
+                name: 'Portugal area',
+                application: 'rw',
+                geostore: '713899292fc118a915741728ef84a2a7',
+                wdpaid: 3,
+                use: { id: 'bbb', name: 'created name' },
+                admin: { adm0: 'createdCountryIso', adm1: 15, adm2: 8 },
+                datasets: '[{"slug":"viirs","name":"VIIRS","startDate":"7","endDate":"1","lastCreate":1513793462776.0,"_id":"5a3aa9eb98b5910011731f66","active":true,"cache":true}]',
+                templateId: 'createdTemplateId'
+            });
+
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('object');
+        response.body.data.should.have.property('type').and.equal('area');
+        response.body.data.should.have.property('id');
+        response.body.data.attributes.should.have.property('name').and.equal('Portugal area');
+        response.body.data.attributes.should.have.property('application').and.equal('rw');
+        response.body.data.attributes.should.have.property('geostore').and.equal('713899292fc118a915741728ef84a2a7');
+        response.body.data.attributes.should.have.property('userId').and.equal(USERS.USER.id);
+        response.body.data.attributes.should.have.property('wdpaid').and.equal(3);
+        response.body.data.attributes.should.have.property('env').and.equal('production');
+        response.body.data.attributes.should.have.property('use').and.deep.equal({ id: 'bbb', name: 'created name' });
+        response.body.data.attributes.should.have.property('admin').and.deep.equal({
+            adm0: 'createdCountryIso',
+            adm1: 15,
+            adm2: 8,
+            source: {
+                provider: 'gadm',
+                version: '3.6',
+            }
+        });
+        response.body.data.attributes.should.have.property('iso').and.eql({});
+        response.body.data.attributes.should.have.property('createdAt');
+        response.body.data.attributes.should.have.property('updatedAt');
+        new Date(response.body.data.attributes.updatedAt).should.closeToTime(new Date(response.body.data.attributes.createdAt), 5);
+        response.body.data.attributes.should.have.property('datasets').and.be.an('array').and.length(1);
+        response.body.data.attributes.datasets[0].should.deep.equal({
+            cache: true,
+            active: true,
+            _id: '5a3aa9eb98b5910011731f66',
+            slug: 'viirs',
+            name: 'VIIRS',
+            startDate: '7',
+            endDate: '1'
+        });
+    });
+
     describe('Custom envs', () => {
 
         it('Creating an area with no env should be successful and have the default env value', async () => {

--- a/app/test/e2e/v2/create-area.spec.js
+++ b/app/test/e2e/v2/create-area.spec.js
@@ -75,7 +75,11 @@ describe('V2 - Create area', () => {
         response.body.data.attributes.should.have.property('use').and.deep.equal({ id: 'bbb', name: 'created name' });
         response.body.data.attributes.should.have.property('iso').and.deep.equal({
             country: 'createdCountryIso',
-            region: 'createdRegionIso'
+            region: 'createdRegionIso',
+            source: {
+                provider: 'gadm',
+                version: '3.6',
+            }
         });
         response.body.data.attributes.should.have.property('createdAt');
         response.body.data.attributes.should.have.property('updatedAt');
@@ -128,7 +132,11 @@ describe('V2 - Create area', () => {
             });
             response.body.data.attributes.should.have.property('iso').and.deep.equal({
                 country: 'createdCountryIso',
-                region: 'createdRegionIso'
+                region: 'createdRegionIso',
+                source: {
+                    provider: 'gadm',
+                    version: '3.6',
+                }
             });
             response.body.data.attributes.should.have.property('createdAt');
             response.body.data.attributes.should.have.property('updatedAt');
@@ -180,7 +188,11 @@ describe('V2 - Create area', () => {
             });
             response.body.data.attributes.should.have.property('iso').and.deep.equal({
                 country: 'createdCountryIso',
-                region: 'createdRegionIso'
+                region: 'createdRegionIso',
+                source: {
+                    provider: 'gadm',
+                    version: '3.6',
+                }
             });
             response.body.data.attributes.should.have.property('createdAt');
             response.body.data.attributes.should.have.property('updatedAt');
@@ -238,7 +250,11 @@ describe('V2 - Create area', () => {
             });
             response.body.data.attributes.should.have.property('iso').and.deep.equal({
                 country: 'createdCountryIso',
-                region: 'createdRegionIso'
+                region: 'createdRegionIso',
+                source: {
+                    provider: 'gadm',
+                    version: '3.6',
+                }
             });
             response.body.data.attributes.should.have.property('createdAt');
             response.body.data.attributes.should.have.property('updatedAt');
@@ -294,7 +310,11 @@ describe('V2 - Create area', () => {
         response.body.data.attributes.should.have.property('use').and.deep.equal({ id: 'bbb', name: 'created name' });
         response.body.data.attributes.should.have.property('iso').and.deep.equal({
             country: 'createdCountryIso',
-            region: 'createdRegionIso'
+            region: 'createdRegionIso',
+            source: {
+                provider: 'gadm',
+                version: '3.6',
+            }
         });
         response.body.data.attributes.should.have.property('createdAt');
         response.body.data.attributes.should.have.property('updatedAt');

--- a/app/test/e2e/v2/update-area.spec.js
+++ b/app/test/e2e/v2/update-area.spec.js
@@ -97,7 +97,11 @@ describe('V2 - Update area', () => {
         });
         response.body.data.attributes.should.have.property('iso').and.deep.equal({
             country: 'updatedCountryIso',
-            region: 'updatedRegionIso'
+            region: 'updatedRegionIso',
+            source: {
+                provider: 'gadm',
+                version: '3.6',
+            }
         });
         response.body.data.attributes.should.have.property('createdAt');
         response.body.data.attributes.should.have.property('updatedAt');
@@ -156,7 +160,11 @@ describe('V2 - Update area', () => {
         });
         response.body.data.attributes.should.have.property('iso').and.deep.equal({
             country: 'updatedCountryIso',
-            region: 'updatedRegionIso'
+            region: 'updatedRegionIso',
+            source: {
+                provider: 'gadm',
+                version: '3.6',
+            }
         });
         response.body.data.attributes.should.have.property('createdAt');
         response.body.data.attributes.should.have.property('updatedAt');
@@ -211,7 +219,11 @@ describe('V2 - Update area', () => {
         });
         response.body.data.attributes.should.have.property('iso').and.deep.equal({
             country: 'updatedCountryIso',
-            region: 'updatedRegionIso'
+            region: 'updatedRegionIso',
+            source: {
+                provider: 'gadm',
+                version: '3.6',
+            }
         });
         response.body.data.attributes.should.have.property('createdAt');
         response.body.data.attributes.should.have.property('updatedAt');

--- a/app/test/unit/serializers/adminSourceUtils.test.js
+++ b/app/test/unit/serializers/adminSourceUtils.test.js
@@ -3,8 +3,6 @@ const { addV1SourceForAdministrativeAreas, addV2SourceForAdministrativeAreas } =
 
 const { expect } = chai;
 
-
-
 describe('adminSourceUtils', () => {
     describe('Adding GADM 2.8 Source Information', () => {
         const serializedAreaFragment = {

--- a/app/test/unit/serializers/adminSourceUtils.test.js
+++ b/app/test/unit/serializers/adminSourceUtils.test.js
@@ -18,6 +18,21 @@ describe('adminSourceUtils', () => {
             addV1SourceForAdministrativeAreas(serializedAreaFragment);
             expect(serializedAreaFragment.attributes.iso).to.deep.include({ source: { provider: 'gadm', version: '2.8' } });
         });
+
+        describe('An Area That Is NOT An Administrative Boundary', () => {
+            const serializedCustomAreaFragment = {
+                attributes: {
+                    name: 'Distrito Central, Francisco Morazán, Honduras',
+                    geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+                    iso: {},
+                }
+            };
+
+            it('should not add source information to the iso attribute', () => {
+                addV1SourceForAdministrativeAreas(serializedCustomAreaFragment);
+                expect(serializedCustomAreaFragment.attributes.iso).to.not.have.property('source');
+            });
+        });
     });
 
     describe('Adding GADM 3.6 Source Information', () => {
@@ -34,6 +49,29 @@ describe('adminSourceUtils', () => {
         it('should add GADM 3.6 source information', () => {
             addV2SourceForAdministrativeAreas(serializedAreaFragment);
             expect(serializedAreaFragment.attributes.iso).to.deep.include({ source: { provider: 'gadm', version: '3.6' } });
+        });
+
+        describe('An Area That Is NOT An Administrative Boundary', () => {
+            const serializedCustomAreaFragment = {
+                attributes: {
+                    name: 'Distrito Central, Francisco Morazán, Honduras',
+                    geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+                    iso: {},
+                    admin: {
+                        adm0: null,
+                    }
+                }
+            };
+
+            it('should not add source information to the iso attribute', () => {
+                addV1SourceForAdministrativeAreas(serializedCustomAreaFragment);
+                expect(serializedCustomAreaFragment.attributes.iso).to.not.have.property('source');
+            });
+
+            it('should not add source information to the admin attribute', () => {
+                addV1SourceForAdministrativeAreas(serializedCustomAreaFragment);
+                expect(serializedCustomAreaFragment.attributes.admin).to.not.have.property('source');
+            });
         });
     });
 });

--- a/app/test/unit/serializers/adminSourceUtils.test.js
+++ b/app/test/unit/serializers/adminSourceUtils.test.js
@@ -1,0 +1,41 @@
+const chai = require('chai');
+const { addV1SourceForAdministrativeAreas, addV2SourceForAdministrativeAreas } = require('serializers/adminSourceUtils');
+
+const { expect } = chai;
+
+
+
+describe('adminSourceUtils', () => {
+    describe('Adding GADM 2.8 Source Information', () => {
+        const serializedAreaFragment = {
+            attributes: {
+                iso: {
+                    country: 'HND',
+                    region: '8',
+                },
+            },
+        };
+
+        it('should add GADM 2.8 source information', () => {
+            addV1SourceForAdministrativeAreas(serializedAreaFragment);
+            expect(serializedAreaFragment.attributes.iso).to.deep.include({ source: { provider: 'gadm', version: '2.8' } });
+        });
+    });
+
+    describe('Adding GADM 3.6 Source Information', () => {
+        const serializedAreaFragment = {
+            attributes: {
+                iso: {
+                    country: 'HND',
+                    region: '8',
+                    subregion: '4',
+                },
+            },
+        };
+
+        it('should add GADM 3.6 source information', () => {
+            addV2SourceForAdministrativeAreas(serializedAreaFragment);
+            expect(serializedAreaFragment.attributes.iso).to.deep.include({ source: { provider: 'gadm', version: '3.6' } });
+        });
+    });
+});

--- a/app/test/unit/serializers/adminSourceUtils.test.js
+++ b/app/test/unit/serializers/adminSourceUtils.test.js
@@ -51,6 +51,24 @@ describe('adminSourceUtils', () => {
             expect(result.attributes.iso).to.deep.include({ source: { provider: 'gadm', version: '3.6' } });
         });
 
+        describe('An Administrative Boundary Area with Both an "iso" and "admin" Property', () => {
+            it('should NOT add source information to an empty "iso" object', () => {
+                const serializedAreaFragmentWithEmptyIsoAndAdmin = {
+                    attributes: {
+                        iso: {},
+                        admin: {
+                            adm0: 'HND',
+                            adm1: 8,
+                            adm2: 4
+                        },
+                    },
+                };
+
+                const result = addV2SourceForAdministrativeAreas(serializedAreaFragmentWithEmptyIsoAndAdmin);
+                expect(result.attributes.iso).to.eql({});
+            });
+        });
+
         describe('An Area That Is NOT An Administrative Boundary', () => {
             const serializedCustomAreaFragment = {
                 attributes: {

--- a/app/test/unit/serializers/adminSourceUtils.test.js
+++ b/app/test/unit/serializers/adminSourceUtils.test.js
@@ -15,8 +15,8 @@ describe('adminSourceUtils', () => {
         };
 
         it('should add GADM 2.8 source information', () => {
-            addV1SourceForAdministrativeAreas(serializedAreaFragment);
-            expect(serializedAreaFragment.attributes.iso).to.deep.include({ source: { provider: 'gadm', version: '2.8' } });
+            const result = addV1SourceForAdministrativeAreas(serializedAreaFragment);
+            expect(result.attributes.iso).to.deep.include({ source: { provider: 'gadm', version: '2.8' } });
         });
 
         describe('An Area That Is NOT An Administrative Boundary', () => {
@@ -29,8 +29,8 @@ describe('adminSourceUtils', () => {
             };
 
             it('should not add source information to the iso attribute', () => {
-                addV1SourceForAdministrativeAreas(serializedCustomAreaFragment);
-                expect(serializedCustomAreaFragment.attributes.iso).to.not.have.property('source');
+                const result = addV1SourceForAdministrativeAreas(serializedCustomAreaFragment);
+                expect(result.attributes.iso).to.not.have.property('source');
             });
         });
     });
@@ -47,8 +47,8 @@ describe('adminSourceUtils', () => {
         };
 
         it('should add GADM 3.6 source information', () => {
-            addV2SourceForAdministrativeAreas(serializedAreaFragment);
-            expect(serializedAreaFragment.attributes.iso).to.deep.include({ source: { provider: 'gadm', version: '3.6' } });
+            const result = addV2SourceForAdministrativeAreas(serializedAreaFragment);
+            expect(result.attributes.iso).to.deep.include({ source: { provider: 'gadm', version: '3.6' } });
         });
 
         describe('An Area That Is NOT An Administrative Boundary', () => {
@@ -64,13 +64,13 @@ describe('adminSourceUtils', () => {
             };
 
             it('should not add source information to the iso attribute', () => {
-                addV1SourceForAdministrativeAreas(serializedCustomAreaFragment);
-                expect(serializedCustomAreaFragment.attributes.iso).to.not.have.property('source');
+                const result = addV1SourceForAdministrativeAreas(serializedCustomAreaFragment);
+                expect(result.attributes.iso).to.not.have.property('source');
             });
 
             it('should not add source information to the admin attribute', () => {
-                addV1SourceForAdministrativeAreas(serializedCustomAreaFragment);
-                expect(serializedCustomAreaFragment.attributes.admin).to.not.have.property('source');
+                const result = addV1SourceForAdministrativeAreas(serializedCustomAreaFragment);
+                expect(result.attributes.admin).to.not.have.property('source');
             });
         });
     });

--- a/app/test/unit/serializers/area.serializer.test.js
+++ b/app/test/unit/serializers/area.serializer.test.js
@@ -37,4 +37,17 @@ describe('Area Serializer', () => {
             });
         });
     });
+
+    describe('An Area That Is NOT An Administrative Boundary', () => {
+        const customArea = {
+            name: 'Distrito Central, Francisco Morazán, Honduras',
+            geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+            iso: {},
+        };
+
+        it('should not add source information to the iso attribute', () => {
+            const result = areaSerializer.serialize(new AreaModel(customArea));
+            expect(result.data.attributes.iso).to.not.have.property('source');
+        });
+    });
 });

--- a/app/test/unit/serializers/area.serializer.test.js
+++ b/app/test/unit/serializers/area.serializer.test.js
@@ -1,0 +1,40 @@
+const chai = require('chai');
+const AreaModel = require('models/area.model');
+const areaSerializer = require('serializers/area.serializer');
+
+const { expect } = chai;
+
+describe('Area Serializer', () => {
+    const area = {
+        name: 'Distrito Central, Francisco Morazán, Honduras',
+        geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+        iso: {
+            country: 'HND',
+            region: '8',
+        },
+    };
+
+    it('should include the name of the Area', () => {
+        const result = areaSerializer.serialize(new AreaModel(area));
+        expect(result.data.attributes.name).to.equal('Distrito Central, Francisco Morazán, Honduras');
+    });
+
+    it('should include the geostore of the Area', () => {
+        const result = areaSerializer.serialize(new AreaModel(area));
+        expect(result.data.attributes.geostore).to.equal('abcf7041e2fbc5e8e7774178157ababe');
+    });
+
+    describe('Administrative Boundary IDs', () => {
+        describe('The ISO attribute', () => {
+            it('should include the country and region', () => {
+                const result = areaSerializer.serialize(new AreaModel(area));
+                expect(result.data.attributes.iso).to.deep.include({ country: 'HND', region: '8', });
+            });
+
+            it('should include the administrative ID provider and version', () => {
+                const result = areaSerializer.serialize(new AreaModel(area));
+                expect(result.data.attributes.iso).to.deep.include({ source: { provider: 'gadm', version: '2.8' } });
+            });
+        });
+    });
+});

--- a/app/test/unit/serializers/area.serializerV2.test.js
+++ b/app/test/unit/serializers/area.serializerV2.test.js
@@ -54,5 +54,26 @@ describe('Area Serializer V2', () => {
                 expect(result.data.attributes.admin).to.deep.include({ source: { provider: 'gadm', version: '3.6' } });
             });
         });
+
+        describe('An Area That Is NOT An Administrative Boundary', () => {
+            const customArea = {
+                name: 'Distrito Central, Francisco Morazán, Honduras',
+                geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+                iso: {},
+                admin: {
+                    adm0: null,
+                }
+            };
+
+            it('should not add source information to the iso attribute', () => {
+                const result = areaSerializerV2.serialize(new AreaModel(customArea));
+                expect(result.data.attributes.iso).to.not.have.property('source');
+            });
+
+            it('should not add source information to the admin attribute', () => {
+                const result = areaSerializerV2.serialize(new AreaModel(customArea));
+                expect(result.data.attributes.admin).to.not.have.property('source');
+            });
+        });
     });
 });

--- a/app/test/unit/serializers/area.serializerV2.test.js
+++ b/app/test/unit/serializers/area.serializerV2.test.js
@@ -37,12 +37,21 @@ describe('Area Serializer V2', () => {
                 expect(result.data.attributes.iso).to.deep.include({ country: 'HND', region: '8', subregion: '4' });
             });
 
+            it('should include the administrative ID provider and version', () => {
+                const result = areaSerializerV2.serialize(new AreaModel(area));
+                expect(result.data.attributes.iso).to.deep.include({ source: { provider: 'gadm', version: '3.6' } });
+            });
         });
 
         describe('The Admin attribute', () => {
             it('should include the adm0, adm1, and adm2 IDs', () => {
                 const result = areaSerializerV2.serialize(new AreaModel(area));
                 expect(result.data.attributes.admin).to.deep.include({ adm0: 'HND', adm1: 8, adm2: 4 });
+            });
+
+            it('should include the administrative ID provider and version', () => {
+                const result = areaSerializerV2.serialize(new AreaModel(area));
+                expect(result.data.attributes.admin).to.deep.include({ source: { provider: 'gadm', version: '3.6' } });
             });
         });
     });

--- a/app/test/unit/serializers/area.serializerV2.test.js
+++ b/app/test/unit/serializers/area.serializerV2.test.js
@@ -1,0 +1,49 @@
+const chai = require('chai');
+const AreaModel = require('models/area.modelV2');
+const areaSerializerV2 = require('serializers/area.serializerV2');
+
+const { expect } = chai;
+
+describe('Area Serializer V2', () => {
+    const area = {
+        name: 'Distrito Central, Francisco Morazán, Honduras',
+        geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+        iso: {
+            country: 'HND',
+            region: '8',
+            subregion: '4',
+        },
+        admin: {
+            adm0: 'HND',
+            adm1: 8,
+            adm2: 4,
+        }
+    };
+
+    it('should include the name of the Area', () => {
+        const result = areaSerializerV2.serialize(new AreaModel(area));
+        expect(result.data.attributes.name).to.equal('Distrito Central, Francisco Morazán, Honduras');
+    });
+
+    it('should include the geostore of the Area', () => {
+        const result = areaSerializerV2.serialize(new AreaModel(area));
+        expect(result.data.attributes.geostore).to.equal('abcf7041e2fbc5e8e7774178157ababe');
+    });
+
+    describe('Administrative Boundary IDs', () => {
+        describe('The ISO attribute', () => {
+            it('should include the country, region, and subregion', () => {
+                const result = areaSerializerV2.serialize(new AreaModel(area));
+                expect(result.data.attributes.iso).to.deep.include({ country: 'HND', region: '8', subregion: '4' });
+            });
+
+        });
+
+        describe('The Admin attribute', () => {
+            it('should include the adm0, adm1, and adm2 IDs', () => {
+                const result = areaSerializerV2.serialize(new AreaModel(area));
+                expect(result.data.attributes.admin).to.deep.include({ adm0: 'HND', adm1: 8, adm2: 4 });
+            });
+        });
+    });
+});

--- a/area.sh
+++ b/area.sh
@@ -5,12 +5,12 @@ case "$1" in
         yarn start
         ;;
     develop)
-        type docker-compose >/dev/null 2>&1 || { echo >&2 "docker-compose is required but it's not installed.  Aborting."; exit 1; }
-        docker-compose -f docker-compose-develop.yml build && docker-compose -f docker-compose-develop.yml up
+        type docker compose >/dev/null 2>&1 || { echo >&2 "docker compose is required but it's not installed.  Aborting."; exit 1; }
+        docker compose -f docker-compose-develop.yml build && docker compose -f docker-compose-develop.yml up
         ;;
     test)
-        type docker-compose >/dev/null 2>&1 || { echo >&2 "docker-compose is required but it's not installed.  Aborting."; exit 1; }
-        docker-compose -f docker-compose-test.yml build && docker-compose -f docker-compose-test.yml up --abort-on-container-exit
+        type docker compose >/dev/null 2>&1 || { echo >&2 "docker compose is required but it's not installed.  Aborting."; exit 1; }
+        docker compose -f docker-compose-test.yml build && docker compose -f docker-compose-test.yml up --abort-on-container-exit
         ;;
     *)
         echo "Usage: area.sh {start|develop|test}" >&2

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -11,12 +11,14 @@ services:
       PORT: 4100
       NODE_ENV: dev
       NODE_PATH: app/src
-      MONGO_PORT_27017_TCP_ADDR: mongo
+      MONGO_PORT_27017_TCP_ADDR: gfw-areas-mongo
       WAIT_HOSTS: mongo:27017
       FASTLY_ENABLED: "false"
       AWS_REGION: "us-east-1"
       AWS_ACCESS_KEY_ID: "test"
       AWS_SECRET_ACCESS_KEY: "test"
+      REQUIRE_API_KEY: "false"
+      AWS_CLOUD_WATCH_LOGGING_ENABLED: "false"
     command: develop
     depends_on:
       - mongo


### PR DESCRIPTION
[Miro](https://miro.com/app/board/uXjVLKsI-90=/?moveToWidget=3458764609724767653&cot=14)

[GTC-3085](https://gfw.atlassian.net/browse/GTC-3085)

This PR adds the administrative source information to the representation of a user's administrative boundary Area. 
It does NOT alter a custom Area.

Currently, an administrative boundary Area has information in either its `iso` or `admin` property:
```js
{
  iso: {
    country: 'HND',
    region: '8'
  },
  admin: {
    adm0: 'HND',
    adm1: '8'
  }
}
```

Implicitly, the IDs refer to specific versions of GADM IDs.

This PR makes the specific version **explicit**:
```js
{
  iso: {
    country: 'HND',
    region: '8',
    source: {
      provider: 'gadm',
      version: '3.6'
    }
  },
  admin: {
    adm0: 'HND',
    adm1: '8',
    source: {
      provider: 'gadm',
      version: '3.6'
    }
  }
}
```
----

# Test
command line:
```shell
clear; NODE_PATH=./src npx mocha test/unit/**/*.test.js
```

docker:
```shell
./area.sh test
```

## Behaviors Tested in this PR
```shell
  adminSourceUtils
    Adding GADM 2.8 Source Information
      ✔ should add GADM 2.8 source information
      An Area That Is NOT An Administrative Boundary
        ✔ should not add source information to the iso attribute
    Adding GADM 3.6 Source Information
      ✔ should add GADM 3.6 source information
      An Administrative Boundary Area with Both an "iso" and "admin" Property
        ✔ should NOT add source information to an empty "iso" object
      An Area That Is NOT An Administrative Boundary
        ✔ should not add source information to the iso attribute
        ✔ should not add source information to the admin attribute

  Area Serializer
    ✔ should include the name of the Area
    ✔ should include the geostore of the Area
    Administrative Boundary IDs
      The ISO attribute
        ✔ should include the country and region
        ✔ should include the administrative ID provider and version
    An Area That Is NOT An Administrative Boundary
      ✔ should not add source information to the iso attribute

  Area Serializer V2
    ✔ should include the name of the Area
    ✔ should include the geostore of the Area
    Administrative Boundary IDs
      The ISO attribute
        ✔ should include the country, region, and subregion
        ✔ should include the administrative ID provider and version
      The Admin attribute
        ✔ should include the adm0, adm1, and adm2 IDs
        ✔ should include the administrative ID provider and version
      An Area That Is NOT An Administrative Boundary
        ✔ should not add source information to the iso attribute
        ✔ should not add source information to the admin attribute

```