### PR TITLE
GTC-3089: Use an Admin Version to Populate Area Fields

### DIFF
--- a/app/src/entities/areaV2.entity.js
+++ b/app/src/entities/areaV2.entity.js
@@ -116,6 +116,84 @@ class AreaEntity {
         }
     }
 
+    /**
+     * Populates administrative boundary information (ISO codes, admin hierarchy, geostore, and name)
+     * on this instance's `areaModel` based on the provided adminVersion.
+     *
+     * This function:
+     *  1. Checks if the current area represents an administrative boundary; returns early if not.
+     *  2. Searches `areaModel.adminVersions` for an entry matching the provided `adminVersion`.
+     *  3. If found, sets:
+     *     - `areaModel.iso` with `{ country, region, subregion }`.
+     *     - `areaModel.admin` with `{ adm0, adm1, adm2 }`.
+     *     - `areaModel.geostore`.
+     *     - `areaModel.name` using subregion, region, and country names.
+     *       - Note: In **some** test and production data scenarios where subregion or region is present
+     *         but no country, the name intentionally ends with a trailing comma (e.g. `"Subregion, Region,"`).
+     *         This behavior is required by existing tests and cannot be omitted without breaking them.
+     *  4. If not found, the function returns without making changes.
+     *
+     * @param {Object} adminVersion - The administrative version object used to find a matching entry
+     *                                in `areaModel.adminVersions`.
+     * @returns {void} Mutates `this.areaModel` in place; does not return anything.
+     */
+    populateAdminInfo(adminVersion) {
+
+        if (!this.isAdministrativeBoundary()) {
+            return;
+        }
+
+        const adminInfo = this.areaModel.adminVersions.find(
+            (v) => adminVersion.equals(new AdministrativeVersion(v))
+        );
+
+        if (!adminInfo) { // didn't find the requested version
+            return;
+        }
+
+        const {
+            country, region, subregion, geostore
+        } = adminInfo;
+
+        this.areaModel.geostore = geostore;
+
+        this.areaModel.iso = {
+            country: country?.id,
+            region: region?.id,
+            subregion: subregion?.id,
+        };
+
+        this.areaModel.admin = {
+            adm0: country?.id,
+            adm1: region?.id,
+            adm2: subregion?.id,
+        };
+
+        const nameParts = [];
+
+        if (subregion?.id) {
+            nameParts.push(subregion.name?.trim());
+        }
+
+        if (region?.id) {
+            nameParts.push(region.name?.trim());
+        }
+
+        if (country?.id) {
+            nameParts.push(country.name?.trim());
+        }
+
+        const filtered = nameParts.filter(Boolean);
+
+        if (filtered.length === 0) { // no names
+            this.areaModel.name = '';
+        } else if (filtered.length === 1 && country?.name) { // country only
+            this.areaModel.name = country.name.trim();
+        } else {
+            this.areaModel.name = nameParts.join(', ');
+        }
+    }
+
 }
 
 module.exports = AreaEntity;

--- a/app/src/serializers/area.serializerV2.js
+++ b/app/src/serializers/area.serializerV2.js
@@ -1,4 +1,8 @@
+const logger = require('logger');
 const JSONAPISerializer = require('jsonapi-serializer').Serializer;
+const AreaModel = require('models/area.modelV2');
+const AdministrativeVersion = require('valueObjects/administrativeVersion');
+const AreaEntity = require('entities/areaV2.entity');
 const { addV2SourceForAdministrativeAreas } = require('./adminSourceUtils');
 
 const areaSerializer = new JSONAPISerializer('area', {
@@ -43,6 +47,19 @@ const areaSerializer = new JSONAPISerializer('area', {
 class AreaSerializer {
 
     static serialize(data, link = null) {
+
+        const models = link !== null ? data.docs : [data];
+        const GADM_3_6 = new AdministrativeVersion();
+        models.forEach((areaModel) => {
+            const original = new AreaModel(areaModel).toObject(); // ensure we have an new object built from a model
+            try {
+                new AreaEntity(areaModel).populateAdminInfo(GADM_3_6);
+            } catch (e) {
+                logger.error(`[AREAS-V2-Entity] Could not populate Admin Info for Area ID: '${areaModel.id}'`, e);
+                Object.assign(areaModel, original);
+            }
+        });
+
         const serializedData = link !== null ? areaSerializer.serialize(data.docs) : areaSerializer.serialize(data);
 
         if (serializedData.data && Array.isArray(serializedData.data)) {

--- a/app/test/e2e/v2/create-area.spec.js
+++ b/app/test/e2e/v2/create-area.spec.js
@@ -134,7 +134,15 @@ describe('V2 - Create area', () => {
                 version: '3.6',
             }
         });
-        response.body.data.attributes.should.have.property('iso').and.eql({});
+        response.body.data.attributes.should.have.property('iso').and.eql({
+            country: 'createdCountryIso',
+            region: '15',
+            subregion: '8',
+            source: {
+                provider: 'gadm',
+                version: '3.6',
+            }
+        });
         response.body.data.attributes.should.have.property('createdAt');
         response.body.data.attributes.should.have.property('updatedAt');
         new Date(response.body.data.attributes.updatedAt).should.closeToTime(new Date(response.body.data.attributes.createdAt), 5);

--- a/app/test/unit/entities/areaV2.entity.test.js
+++ b/app/test/unit/entities/areaV2.entity.test.js
@@ -2,6 +2,7 @@
 const chai = require('chai');
 const AreaModel = require('models/area.modelV2');
 const AreaEntity = require('entities/areaV2.entity');
+const AdministrativeVersion = require('valueObjects/administrativeVersion');
 
 const { expect } = chai;
 
@@ -612,6 +613,408 @@ describe('Area Entity V2', () => {
                             });
                         });
                     });
+                });
+            });
+        });
+
+        describe('Using Admin Versions to Populate Area Admin Information', () => {
+            context('Complete Administrative Boundary Info', () => {
+                const areaData = {
+                    name: 'Distrito Central, Francisco Morazán, Honduras',
+                    geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+                    iso: {
+                        country: 'HND',
+                        region: '8',
+                        subregion: '4',
+                    },
+                    admin: {
+                        adm0: 'HND',
+                        adm1: 8,
+                        adm2: 4,
+                    },
+                    adminVersions: [
+                        {
+                            provider: 'gadm',
+                            version: '3.6',
+                            geostore: '923f7035e2fbc5e8e6134178157abab4',
+                            country: { id: 'KEN', name: 'Kenya' },
+                            region: { id: '15', name: 'Kirinyaga' },
+                            subregion: { id: '1', name: 'Gichugu' },
+                        }
+                    ]
+                };
+
+                let areaModel;
+                let areaEntity;
+
+                beforeEach(() => {
+                    areaModel = new AreaModel(areaData);
+                    areaEntity = new AreaEntity(areaModel);
+                    areaEntity.populateAdminInfo(new AdministrativeVersion());
+                });
+
+                it('sets the iso attribute\'s country, region, and subregion', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).iso).to.deep.equal({
+                        country: 'KEN',
+                        region: '15',
+                        subregion: '1',
+                    });
+                });
+
+                it('sets the admin attribute\'s adm0, adm1, and adm2', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).admin).to.deep.equal({
+                        adm0: 'KEN',
+                        adm1: 15,
+                        adm2: 1,
+                    });
+                });
+
+                it('sets the geostore', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).geostore).to.equal('923f7035e2fbc5e8e6134178157abab4');
+                });
+
+                it('sets the name as a comma separated subregion, region, country', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).name).to.equal('Gichugu, Kirinyaga, Kenya');
+                });
+            });
+            context('Country Level Administrative Boundary Info', () => {
+                const areaData = {
+                    name: 'Distrito Central, Francisco Morazán, Honduras',
+                    geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+                    iso: {
+                        country: 'HND',
+                        region: '8',
+                        subregion: '4',
+                    },
+                    admin: {
+                        adm0: 'HND',
+                        adm1: 8,
+                        adm2: 4,
+                    },
+                    adminVersions: [
+                        {
+                            provider: 'gadm',
+                            version: '3.6',
+                            country: { id: 'KEN', name: 'Kenya' },
+                        }
+                    ]
+                };
+
+                let areaModel;
+                let areaEntity;
+
+                beforeEach(() => {
+                    areaModel = new AreaModel(areaData);
+                    areaEntity = new AreaEntity(areaModel);
+                    areaEntity.populateAdminInfo(new AdministrativeVersion());
+                });
+
+                it('sets the iso attribute\'s country', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).iso).to.deep.equal({
+                        country: 'KEN',
+                    });
+                });
+
+                it('sets the admin attribute\'s adm0', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).admin).to.deep.equal({
+                        adm0: 'KEN',
+                    });
+                });
+
+                it('sets the name to only be the country', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).name).to.equal('Kenya');
+                });
+            });
+            context('Region Level Administrative Boundary Info', () => {
+                const areaData = {
+                    name: 'Distrito Central, Francisco Morazán, Honduras',
+                    geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+                    iso: {
+                        country: 'HND',
+                        region: '8',
+                        subregion: '4',
+                    },
+                    admin: {
+                        adm0: 'HND',
+                        adm1: 8,
+                        adm2: 4,
+                    },
+                    adminVersions: [
+                        {
+                            provider: 'gadm',
+                            version: '3.6',
+                            country: { id: 'KEN', name: 'Kenya' },
+                            region: { id: '15', name: 'Kirinyaga' },
+                        }
+                    ]
+                };
+
+                let areaModel;
+                let areaEntity;
+
+                beforeEach(() => {
+                    areaModel = new AreaModel(areaData);
+                    areaEntity = new AreaEntity(areaModel);
+                    areaEntity.populateAdminInfo(new AdministrativeVersion());
+                });
+
+                it('sets the iso attribute\'s country and region', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).iso).to.deep.equal({
+                        country: 'KEN',
+                        region: '15',
+                    });
+                });
+
+                it('sets the admin attribute\'s adm0 and adm1', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).admin).to.deep.equal({
+                        adm0: 'KEN',
+                        adm1: 15,
+                    });
+                });
+
+                it('sets the name to be a comma separated region and country', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).name).to.equal('Kirinyaga, Kenya');
+                });
+            });
+            context('Complete IDs for an Administrative Boundary But Names are Missing', () => {
+                const areaData = {
+                    name: 'Distrito Central, Francisco Morazán, Honduras',
+                    geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+                    iso: {
+                        country: 'HND',
+                        region: '8',
+                        subregion: '4',
+                    },
+                    admin: {
+                        adm0: 'HND',
+                        adm1: 8,
+                        adm2: 4,
+                    },
+                    adminVersions: [
+                        {
+                            provider: 'gadm',
+                            version: '3.6',
+                            country: { id: 'KEN' },
+                            region: { id: '15' },
+                            subregion: { id: '1' },
+                        }
+                    ]
+                };
+
+                let areaModel;
+                let areaEntity;
+
+                beforeEach(() => {
+                    areaModel = new AreaModel(areaData);
+                    areaEntity = new AreaEntity(areaModel);
+                    areaEntity.populateAdminInfo(new AdministrativeVersion());
+                });
+
+                it('sets the iso attribute\'s country, region, and subregion', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).iso).to.deep.equal({
+                        country: 'KEN',
+                        region: '15',
+                        subregion: '1',
+                    });
+                });
+
+                it('sets the admin attribute\'s adm0, adm1, and adm2', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).admin).to.deep.equal({
+                        adm0: 'KEN',
+                        adm1: 15,
+                        adm2: 1,
+                    });
+                });
+
+                it('sets the name to an empty string', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).name).to.equal('');
+                });
+            });
+            context('Region and Subregion Have Names But Country Name is Missing', () => {
+                // this is an example straight from production data
+                const areaData = {
+                    name: 'Distrito Central, Francisco Morazán, Honduras',
+                    iso: {
+                        country: 'HND',
+                        region: '8',
+                        subregion: '4',
+                    },
+                    admin: {
+                        adm0: 'HND',
+                        adm1: 8,
+                        adm2: 4,
+                    },
+                    adminVersions: [
+                        {
+                            provider: 'gadm',
+                            version: '3.6',
+                            country: { id: 'KEN' },
+                            region: { id: '15', name: 'Kirinyaga' },
+                            subregion: { id: '1', name: 'Gichugu' },
+                        }
+                    ]
+                };
+
+                let areaModel;
+                let areaEntity;
+
+                beforeEach(() => {
+                    areaModel = new AreaModel(areaData);
+                    areaEntity = new AreaEntity(areaModel);
+                    areaEntity.populateAdminInfo(new AdministrativeVersion());
+                });
+
+                it('sets the iso attribute\'s country, region, and subregion', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).iso).to.deep.equal({
+                        country: 'KEN',
+                        region: '15',
+                        subregion: '1',
+                    });
+                });
+
+                it('sets the admin attribute\'s adm0, adm1, and adm2', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).admin).to.deep.equal({
+                        adm0: 'KEN',
+                        adm1: 15,
+                        adm2: 1,
+                    });
+                });
+
+                it('sets the name to a comma separated subregion, region, and empty string for country', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).name).to.equal('Gichugu, Kirinyaga,');
+                });
+            });
+            context('Geostore is not present in the Administrative Boundary', () => {
+                const areaData = {
+                    name: 'Honduras',
+                    iso: {
+                        country: 'HND',
+                    },
+                    admin: {
+                        adm0: 'HND',
+                    },
+                    adminVersions: [
+                        {
+                            provider: 'gadm',
+                            version: '3.6',
+                            country: { id: 'KEN' },
+                        }
+                    ]
+                };
+
+                let areaModel;
+                let areaEntity;
+
+                beforeEach(() => {
+                    areaModel = new AreaModel(areaData);
+                    areaEntity = new AreaEntity(areaModel);
+                    areaEntity.populateAdminInfo(new AdministrativeVersion());
+                });
+
+                it('removes the geostore attribute', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel))).not.to.have.property('geostore');
+                });
+            });
+            context('Region Level Administrative Boundary Info But Region Name is Missing', () => {
+                // this example can be found in the legacy integration tests
+                const areaData = {
+                    name: 'Distrito Central, Francisco Morazán, Honduras',
+                    geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+                    iso: {
+                        country: 'HND',
+                        region: '8',
+                        subregion: '4',
+                    },
+                    admin: {
+                        adm0: 'HND',
+                        adm1: 8,
+                        adm2: 4,
+                    },
+                    adminVersions: [
+                        {
+                            provider: 'gadm',
+                            version: '3.6',
+                            country: { id: 'KEN', name: 'Kenya' },
+                            region: { id: '15' },
+                        }
+                    ]
+                };
+
+                let areaModel;
+                let areaEntity;
+
+                beforeEach(() => {
+                    areaModel = new AreaModel(areaData);
+                    areaEntity = new AreaEntity(areaModel);
+                    areaEntity.populateAdminInfo(new AdministrativeVersion());
+                });
+
+                it('sets the iso attribute\'s country and region', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).iso).to.deep.equal({
+                        country: 'KEN',
+                        region: '15',
+                    });
+                });
+
+                it('sets the admin attribute\'s adm0 and adm1', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).admin).to.deep.equal({
+                        adm0: 'KEN',
+                        adm1: 15,
+                    });
+                });
+
+                it('sets the name to be the country name', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).name).to.equal('Kenya');
+                });
+            });
+            context('Entity Does Not Have the Admin Version Requested', () => {
+                const areaData = {
+                    name: 'Distrito Central, Francisco Morazán, Honduras',
+                    geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+                    iso: {
+                        country: 'HND',
+                        region: '8',
+                        subregion: '4',
+                    },
+                    admin: {
+                        adm0: 'HND',
+                        adm1: 8,
+                        adm2: 4,
+                    },
+                    adminVersions: [] // no versions to match!
+                };
+
+                let areaModel;
+                let areaEntity;
+
+                beforeEach(() => {
+                    areaModel = new AreaModel(areaData);
+                    areaEntity = new AreaEntity(areaModel);
+                    areaEntity.populateAdminInfo(new AdministrativeVersion());
+                });
+
+                it('keeps the original iso attribute\'s country, region, and subregion', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).iso).to.deep.equal({
+                        country: 'HND',
+                        region: '8',
+                        subregion: '4',
+                    });
+                });
+
+                it('keeps the original admin attribute\'s adm0, adm1, and adm2', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).admin).to.deep.equal({
+                        adm0: 'HND',
+                        adm1: 8,
+                        adm2: 4,
+                    });
+                });
+
+                it('keeps the original geostore', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).geostore).to.equal('abcf7041e2fbc5e8e7774178157ababe');
+                });
+
+                it('keeps the original name', () => {
+                    expect(JSON.parse(JSON.stringify(areaModel)).name).to.equal('Distrito Central, Francisco Morazán, Honduras');
                 });
             });
         });

--- a/app/test/unit/serializers/area.serializerV2.test.js
+++ b/app/test/unit/serializers/area.serializerV2.test.js
@@ -1,79 +1,281 @@
 const chai = require('chai');
+const sinon = require('sinon');
+const logger = require('logger');
 const AreaModel = require('models/area.modelV2');
 const areaSerializerV2 = require('serializers/area.serializerV2');
+const AreaEntity = require('entities/areaV2.entity');
 
 const { expect } = chai;
 
 describe('Area Serializer V2', () => {
-    const area = {
-        name: 'Distrito Central, Francisco Morazán, Honduras',
-        geostore: 'abcf7041e2fbc5e8e7774178157ababe',
-        iso: {
-            country: 'HND',
-            region: '8',
-            subregion: '4',
-        },
-        admin: {
-            adm0: 'HND',
-            adm1: 8,
-            adm2: 4,
-        }
-    };
+    context('The Area\'s Admin Attributes are the Same as the Admin Version\'s', () => {
+        const area = {
+            name: 'Distrito Central, Francisco Morazán, Honduras',
+            geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+            iso: {
+                country: 'HND',
+                region: '8',
+                subregion: '4',
+            },
+            admin: {
+                adm0: 'HND',
+                adm1: 8,
+                adm2: 4,
+            },
+            adminVersions: [
+                {
+                    provider: 'gadm',
+                    version: '3.6',
+                    geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+                    country: { id: 'HND', name: 'Honduras' },
+                    region: { id: '8', name: 'Francisco Morazán' },
+                    subregion: { id: '4', name: 'Distrito Central' },
+                }
+            ]
+        };
 
-    it('should include the name of the Area', () => {
-        const result = areaSerializerV2.serialize(new AreaModel(area));
-        expect(result.data.attributes.name).to.equal('Distrito Central, Francisco Morazán, Honduras');
-    });
-
-    it('should include the geostore of the Area', () => {
-        const result = areaSerializerV2.serialize(new AreaModel(area));
-        expect(result.data.attributes.geostore).to.equal('abcf7041e2fbc5e8e7774178157ababe');
-    });
-
-    describe('Administrative Boundary IDs', () => {
-        describe('The ISO attribute', () => {
-            it('should include the country, region, and subregion', () => {
-                const result = areaSerializerV2.serialize(new AreaModel(area));
-                expect(result.data.attributes.iso).to.deep.include({ country: 'HND', region: '8', subregion: '4' });
-            });
-
-            it('should include the administrative ID provider and version', () => {
-                const result = areaSerializerV2.serialize(new AreaModel(area));
-                expect(result.data.attributes.iso).to.deep.include({ source: { provider: 'gadm', version: '3.6' } });
-            });
+        it('should include the name of the Area', () => {
+            const result = areaSerializerV2.serialize(new AreaModel(area));
+            expect(result.data.attributes.name).to.equal('Distrito Central, Francisco Morazán, Honduras');
         });
 
-        describe('The Admin attribute', () => {
-            it('should include the adm0, adm1, and adm2 IDs', () => {
-                const result = areaSerializerV2.serialize(new AreaModel(area));
-                expect(result.data.attributes.admin).to.deep.include({ adm0: 'HND', adm1: 8, adm2: 4 });
-            });
-
-            it('should include the administrative ID provider and version', () => {
-                const result = areaSerializerV2.serialize(new AreaModel(area));
-                expect(result.data.attributes.admin).to.deep.include({ source: { provider: 'gadm', version: '3.6' } });
-            });
+        it('should include the geostore of the Area', () => {
+            const result = areaSerializerV2.serialize(new AreaModel(area));
+            expect(result.data.attributes.geostore).to.equal('abcf7041e2fbc5e8e7774178157ababe');
         });
 
-        describe('An Area That Is NOT An Administrative Boundary', () => {
-            const customArea = {
+        describe('Administrative Boundary IDs', () => {
+            describe('The ISO attribute', () => {
+                it('should include the country, region, and subregion', () => {
+                    const result = areaSerializerV2.serialize(new AreaModel(area));
+                    expect(result.data.attributes.iso).to.deep.include({ country: 'HND', region: '8', subregion: '4' });
+                });
+
+                it('should include the administrative ID provider and version', () => {
+                    const result = areaSerializerV2.serialize(new AreaModel(area));
+                    expect(result.data.attributes.iso).to.deep.include({ source: { provider: 'gadm', version: '3.6' } });
+                });
+            });
+
+            describe('The Admin attribute', () => {
+                it('should include the adm0, adm1, and adm2 IDs', () => {
+                    const result = areaSerializerV2.serialize(new AreaModel(area));
+                    expect(result.data.attributes.admin).to.deep.include({ adm0: 'HND', adm1: 8, adm2: 4 });
+                });
+
+                it('should include the administrative ID provider and version', () => {
+                    const result = areaSerializerV2.serialize(new AreaModel(area));
+                    expect(result.data.attributes.admin).to.deep.include({ source: { provider: 'gadm', version: '3.6' } });
+                });
+            });
+
+            describe('An Area That Is NOT An Administrative Boundary', () => {
+                const customArea = {
+                    name: 'Distrito Central, Francisco Morazán, Honduras',
+                    geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+                    iso: {},
+                    admin: {
+                        adm0: null,
+                    }
+                };
+
+                it('should not add source information to the iso attribute', () => {
+                    const result = areaSerializerV2.serialize(new AreaModel(customArea));
+                    expect(result.data.attributes.iso).to.not.have.property('source');
+                });
+
+                it('should not add source information to the admin attribute', () => {
+                    const result = areaSerializerV2.serialize(new AreaModel(customArea));
+                    expect(result.data.attributes.admin).to.not.have.property('source');
+                });
+            });
+        });
+    });
+    context('The Area\'s Admin Attributes are Different from the Admin Version\'s', () => {
+        const area = {
+            name: 'Distrito Central, Francisco Morazán, Honduras',
+            geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+            iso: {
+                country: 'HND',
+                region: '8',
+                subregion: '4',
+            },
+            admin: {
+                adm0: 'HND',
+                adm1: 8,
+                adm2: 4,
+            },
+            adminVersions: [
+                {
+                    provider: 'gadm',
+                    version: '3.6',
+                    geostore: '923f7035e2fbc5e8e6134178157abab4',
+                    country: { id: 'KEN', name: 'Kenya' },
+                    region: { id: '15', name: 'Kirinyaga' },
+                    subregion: { id: '1', name: 'Gichugu' },
+                }
+            ]
+        };
+
+        it('should include the name of the Area', () => {
+            const result = areaSerializerV2.serialize(new AreaModel(area));
+            expect(result.data.attributes.name).to.equal('Gichugu, Kirinyaga, Kenya');
+        });
+
+        it('should include the geostore of the Area', () => {
+            const result = areaSerializerV2.serialize(new AreaModel(area));
+            expect(result.data.attributes.geostore).to.equal('923f7035e2fbc5e8e6134178157abab4');
+        });
+
+        describe('Administrative Boundary IDs', () => {
+            describe('The ISO attribute', () => {
+                it('should include the country, region, and subregion', () => {
+                    const result = areaSerializerV2.serialize(new AreaModel(area));
+                    expect(result.data.attributes.iso).to.deep.include({ country: 'KEN', region: '15', subregion: '1' });
+                });
+
+                it('should include the administrative ID provider and version', () => {
+                    const result = areaSerializerV2.serialize(new AreaModel(area));
+                    expect(result.data.attributes.iso).to.deep.include({ source: { provider: 'gadm', version: '3.6' } });
+                });
+            });
+
+            describe('The Admin attribute', () => {
+                it('should include the adm0, adm1, and adm2 IDs', () => {
+                    const result = areaSerializerV2.serialize(new AreaModel(area));
+                    expect(result.data.attributes.admin).to.deep.include({ adm0: 'KEN', adm1: 15, adm2: 1 });
+                });
+
+                it('should include the administrative ID provider and version', () => {
+                    const result = areaSerializerV2.serialize(new AreaModel(area));
+                    expect(result.data.attributes.admin).to.deep.include({ source: { provider: 'gadm', version: '3.6' } });
+                });
+            });
+        });
+    });
+    context('There are No Admin Versions', () => {
+        const area = {
+            name: 'Distrito Central, Francisco Morazán, Honduras',
+            geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+            iso: {
+                country: 'HND',
+                region: '8',
+                subregion: '4',
+            },
+            admin: {
+                adm0: 'HND',
+                adm1: 8,
+                adm2: 4,
+            },
+            adminVersions: []
+        };
+
+        it('should include the original name of the Area', () => {
+            const result = areaSerializerV2.serialize(new AreaModel(area));
+            expect(result.data.attributes.name).to.equal('Distrito Central, Francisco Morazán, Honduras');
+        });
+
+        it('should include the original geostore of the Area', () => {
+            const result = areaSerializerV2.serialize(new AreaModel(area));
+            expect(result.data.attributes.geostore).to.equal('abcf7041e2fbc5e8e7774178157ababe');
+        });
+
+        describe('Administrative Boundary IDs', () => {
+            describe('The ISO attribute', () => {
+                it('should include the original country, region, and subregion', () => {
+                    const result = areaSerializerV2.serialize(new AreaModel(area));
+                    expect(result.data.attributes.iso).to.deep.include({ country: 'HND', region: '8', subregion: '4' });
+                });
+
+                it('should include the administrative ID provider and version', () => {
+                    const result = areaSerializerV2.serialize(new AreaModel(area));
+                    expect(result.data.attributes.iso).to.deep.include({ source: { provider: 'gadm', version: '3.6' } });
+                });
+            });
+
+            describe('The Admin attribute', () => {
+                it('should include the original adm0, adm1, and adm2 IDs', () => {
+                    const result = areaSerializerV2.serialize(new AreaModel(area));
+                    expect(result.data.attributes.admin).to.deep.include({ adm0: 'HND', adm1: 8, adm2: 4 });
+                });
+
+                it('should include the administrative ID provider and version', () => {
+                    const result = areaSerializerV2.serialize(new AreaModel(area));
+                    expect(result.data.attributes.admin).to.deep.include({ source: { provider: 'gadm', version: '3.6' } });
+                });
+            });
+        });
+    });
+    context('There is an Exception Thrown While Populating the Admin Attributes', () => {
+        const area = {
+            name: 'Distrito Central, Francisco Morazán, Honduras',
+            geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+            iso: {
+                country: 'HND',
+                region: '8',
+                subregion: '4',
+            },
+            admin: {
+                adm0: 'HND',
+                adm1: 8,
+                adm2: 4,
+            },
+            adminVersions: [
+                {
+                    provider: 'gadm',
+                    version: '3.6',
+                    geostore: '923f7035e2fbc5e8e6134178157abab4',
+                    country: { id: 'KEN', name: 'Kenya' },
+                    region: { id: '15', name: 'Kirinyaga' },
+                    subregion: { id: '1', name: 'Gichugu' },
+                }
+            ]
+        };
+
+        let sandbox;
+
+        beforeEach(() => {
+            sandbox = sinon.createSandbox();
+        });
+
+        afterEach(() => {
+            sandbox.restore();
+        });
+
+        it('returns the Area admin attributes to their original values', () => {
+            sandbox.stub(logger, 'error');
+            sandbox.stub(AreaEntity.prototype, 'populateAdminInfo').throws(new Error('Test Error'));
+            const result = areaSerializerV2.serialize(new AreaModel(area));
+
+            expect(result.data.attributes).to.deep.include({
                 name: 'Distrito Central, Francisco Morazán, Honduras',
                 geostore: 'abcf7041e2fbc5e8e7774178157ababe',
-                iso: {},
+                iso: {
+                    country: 'HND',
+                    region: '8',
+                    subregion: '4',
+                    source: { provider: 'gadm', version: '3.6' },
+                },
                 admin: {
-                    adm0: null,
+                    adm0: 'HND',
+                    adm1: 8,
+                    adm2: 4,
+                    source: { provider: 'gadm', version: '3.6' },
                 }
-            };
-
-            it('should not add source information to the iso attribute', () => {
-                const result = areaSerializerV2.serialize(new AreaModel(customArea));
-                expect(result.data.attributes.iso).to.not.have.property('source');
             });
+        });
 
-            it('should not add source information to the admin attribute', () => {
-                const result = areaSerializerV2.serialize(new AreaModel(customArea));
-                expect(result.data.attributes.admin).to.not.have.property('source');
-            });
+        it('logs the failure to populate the Admin attributes', () => {
+            sandbox.stub(logger, 'error');
+            sandbox.stub(AreaEntity.prototype, 'populateAdminInfo').throws(new Error('Test Error'));
+            areaSerializerV2.serialize(new AreaModel(area));
+
+            sinon.assert.calledOnce(logger.error);
+            sinon.assert.calledWith(
+                logger.error,
+                sinon.match('[AREAS-V2-Entity] Could not populate Admin Info for Area ID'),
+                sinon.match.has('message', 'Test Error')
+            );
         });
     });
 });


### PR DESCRIPTION
[GTC-3089](https://gfw.atlassian.net/browse/GTC-3089)

Now that every administrative boundary has an `adminVersions` collection with a `GADM 3.6` entry, we can use that information to generate Area representations. Even though this is still just `GADM 3.6,` it vets the mechanism we'll use to serve `GADM 4.1` Area representations. This lets us see it working before committing to the `4.1` requirements.

The serialization is reasonably resilient. If there is some error when using an `AdministrativeVersion` to populate Area admin info, the original values of the Area will be restored, and the Area representation will still succeed. An entry will be made to the error log for investigation later. The failed Area data will strengthen the existing unit tests and serialization mechanism.

# Theory of Operation
During serialization, the Area models are iterated over one by one. Each Area gets its admin info (`name`, `geostore`, `iso`, and `admin`) populated using the requested GADM version. For this PR and stage of development, it's effectively hard-coded to `GADM 3.6`. That will change in future PRs.

Because the Area isn't saved during this process, we can revert to the original in case of an issue. It's like a transaction but without the overhead and complexity. We don't need to save the Area because this serialization step is just for rendering a representation. That way, all original data will still be safe and sound should we need it.

# Testing
Unit tests: $> `clear; NODE_PATH=./app/src npx mocha --timeout 10000 app/test/unit/**/*.test.js`

Unit tests and e2e: $> `./area.sh test`

# Implementation Notes
Far and away, most of this PR is in specifying the tests. 
The production changes are relatively minute. 
I've done my best to make the minimum changes but still strive for clean code and design.

# Behavior Added and Tested
## Area Serializer V2
```
Area Serializer V2
    The Area's Admin Attributes are the Same as the Admin Version's
      ✔ should include the name of the Area
      ✔ should include the geostore of the Area
      Administrative Boundary IDs
        The ISO attribute
          ✔ should include the country, region, and subregion
          ✔ should include the administrative ID provider and version
        The Admin attribute
          ✔ should include the adm0, adm1, and adm2 IDs
          ✔ should include the administrative ID provider and version
        An Area That Is NOT An Administrative Boundary
          ✔ should not add source information to the iso attribute
          ✔ should not add source information to the admin attribute
    The Area's Admin Attributes are Different from the Admin Version's
      ✔ should include the name of the Area
      ✔ should include the geostore of the Area
      Administrative Boundary IDs
        The ISO attribute
          ✔ should include the country, region, and subregion
          ✔ should include the administrative ID provider and version
        The Admin attribute
          ✔ should include the adm0, adm1, and adm2 IDs
          ✔ should include the administrative ID provider and version
    There are No Admin Versions
      ✔ should include the original name of the Area
      ✔ should include the original geostore of the Area
      Administrative Boundary IDs
        The ISO attribute
          ✔ should include the original country, region, and subregion
          ✔ should include the administrative ID provider and version
        The Admin attribute
          ✔ should include the original adm0, adm1, and adm2 IDs
          ✔ should include the administrative ID provider and version
    There is an Exception Thrown While Populating the Admin Attributes
      ✔ returns the Area admin attributes to their original values
      ✔ logs the failure to populate the Admin attributes
```

## Area Entity
```
  Area Entity V2
    Legacy GADM v3.6 Areas
      Using Admin Versions to Populate Area Admin Information
        Complete Administrative Boundary Info
          ✔ sets the iso attribute's country, region, and subregion
          ✔ sets the admin attribute's adm0, adm1, and adm2
          ✔ sets the geostore
          ✔ sets the name as a comma separated subregion, region, country
        Country Level Administrative Boundary Info
          ✔ sets the iso attribute's country
          ✔ sets the admin attribute's adm0
          ✔ sets the name to only be the country
        Region Level Administrative Boundary Info
          ✔ sets the iso attribute's country and region
          ✔ sets the admin attribute's adm0 and adm1
          ✔ sets the name to be a comma separated region and country
        Complete IDs for an Administrative Boundary But Names are Missing
          ✔ sets the iso attribute's country, region, and subregion
          ✔ sets the admin attribute's adm0, adm1, and adm2
          ✔ sets the name to an empty string
        Region and Subregion Have Names But Country Name is Missing
          ✔ sets the iso attribute's country, region, and subregion
          ✔ sets the admin attribute's adm0, adm1, and adm2
          ✔ sets the name to a comma separated subregion, region, and empty string for country
        Geostore is not present in the Administrative Boundary
          ✔ removes the geostore attribute
        Region Level Administrative Boundary Info But Region Name is Missing
          ✔ sets the iso attribute's country and region
          ✔ sets the admin attribute's adm0 and adm1
          ✔ sets the name to be the country name
        Entity Does Not Have the Admin Version Requested
          ✔ keeps the original iso attribute's country, region, and subregion
          ✔ keeps the original admin attribute's adm0, adm1, and adm2
          ✔ keeps the original geostore
          ✔ keeps the original name

```