### PR TITLE
add area id to subscription

### DIFF
--- a/app/src/services/subscription.service.js
+++ b/app/src/services/subscription.service.js
@@ -70,6 +70,8 @@ class SubscriptionsService {
             }
         }
 
+        body.params = { ...body.params, 'area': area.id }
+
         return body;
     }
 

--- a/app/src/services/subscription.service.js
+++ b/app/src/services/subscription.service.js
@@ -42,11 +42,11 @@ class SubscriptionsService {
             body.params = { wdpaid: area.wdpaid };
         }
 
-        if (area.use.name && area.use.id) {
+        if (area.use?.name && area.use?.id) {
             body.params = { use: area.use.name, useid: area.use.id };
         }
 
-        if (area.iso.country) {
+        if (area.iso?.country) {
             body.params = { iso: {} };
 
             if (area.iso.region) {
@@ -58,7 +58,7 @@ class SubscriptionsService {
             }
         }
 
-        if (area.admin.adm0) {
+        if (area.admin?.adm0) {
             body.params = { iso: {} };
 
             if (area.admin.adm1) {

--- a/app/src/services/subscription.service.js
+++ b/app/src/services/subscription.service.js
@@ -70,7 +70,7 @@ class SubscriptionsService {
             }
         }
 
-        body.params = { ...body.params, 'area': area.id }
+        body.params = { ...body.params, area: area._id };
 
         return body;
     }

--- a/app/test/unit/services/subscription.service.test.js
+++ b/app/test/unit/services/subscription.service.test.js
@@ -1,0 +1,57 @@
+const chai = require('chai');
+const SubscriptionsService = require('services/subscription.service');
+
+const { expect } = chai;
+
+describe('Subscription Service', () => {
+    const mockArea = {
+        application: 'gfw',
+        env: 'production',
+        tags: [],
+        status: 'saved',
+        public: false,
+        fireAlerts: true,
+        deforestationAlerts: true,
+        webhookUrl: '',
+        monthlySummary: false,
+        subscriptionId: '',
+        email: 'test.email@wri.org',
+        language: 'en',
+        _id: '7604df303569488fbf928561',
+        name: 'Kiambu, Kenya',
+        geostore: '33b01a49bf9b56a8b56ce042a24f6567',
+        wdpaid: null,
+        userId: 'user123',
+        admin: { adm0: 'KEN', adm1: '13' },
+        datasets: [],
+        image: '',
+        deforestationAlertsType: 'glad-all',
+        createdAt: '2025-01-21T14:20:05.453Z',
+        updatedAt: '2025-01-21T14:20:05.453Z',
+        adminVersions: [
+            {
+                provider: 'gadm',
+                version: '3.6',
+                geostore: '33b01a49bf9b56a8b56ce042a24f6567',
+                country: {},
+                region: {}
+            }
+        ],
+        __v: 0
+    };
+
+    it('should construct the correct subscription body for a given area', () => {
+        const result = SubscriptionsService.getRequestBodyForSubscriptionFromArea(mockArea);
+
+        expect(result).to.be.an('object');
+        expect(result.name).to.equal('Kiambu, Kenya');
+        expect(result.language).to.equal('en');
+        expect(result.datasets).to.deep.equal(['glad-all', 'viirs-active-fires']);
+        expect(result.userId).to.equal('user123');
+        expect(result.params).to.deep.equal({
+            iso: { country: 'KEN', region: '13' },
+            area: '7604df303569488fbf928561',
+        });
+
+    });
+});

--- a/app/test/unit/services/subscription.service.test.js
+++ b/app/test/unit/services/subscription.service.test.js
@@ -43,15 +43,19 @@ describe('Subscription Service', () => {
     it('should construct the correct subscription body for a given area', () => {
         const result = SubscriptionsService.getRequestBodyForSubscriptionFromArea(mockArea);
 
-        expect(result).to.be.an('object');
-        expect(result.name).to.equal('Kiambu, Kenya');
-        expect(result.language).to.equal('en');
-        expect(result.datasets).to.deep.equal(['glad-all', 'viirs-active-fires']);
-        expect(result.userId).to.equal('user123');
-        expect(result.params).to.deep.equal({
-            iso: { country: 'KEN', region: '13' },
-            area: '7604df303569488fbf928561',
+        expect(result).to.deep.includes({
+            name: 'Kiambu, Kenya',
+            language: 'en',
+            userId: 'user123',
+            params: {
+                iso: { country: 'KEN', region: '13' },
+                area: '7604df303569488fbf928561',
+            }
         });
+    });
 
+    it('should have the correct subscription datasets', () => {
+        const result = SubscriptionsService.getRequestBodyForSubscriptionFromArea(mockArea);
+        expect(result.datasets).to.have.members(['glad-all', 'viirs-active-fires']);
     });
 });

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -3,16 +3,16 @@ services:
   develop:
     build: .
     ports:
-      - "4200:4100"
+      - "30504:30504"
     container_name: gfw-area
     env_file:
       - dev.env
     environment:
-      PORT: 4100
+      PORT: 30504
       NODE_ENV: dev
       NODE_PATH: app/src
       MONGO_PORT_27017_TCP_ADDR: gfw-areas-mongo
-      WAIT_HOSTS: mongo:27017
+      WAIT_HOSTS: gfw-areas-mongo
       FASTLY_ENABLED: "false"
       AWS_REGION: "us-east-1"
       AWS_ACCESS_KEY_ID: "test"

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -3,12 +3,12 @@ services:
   develop:
     build: .
     ports:
-      - "30504:30504"
+      - "30504:4100"
     container_name: gfw-area
     env_file:
       - dev.env
     environment:
-      PORT: 30504
+      PORT: 4100
       NODE_ENV: dev
       NODE_PATH: app/src
       MONGO_PORT_27017_TCP_ADDR: gfw-areas-mongo


### PR DESCRIPTION
This adds the area id to subscriptions on creation and update. FYI the subscription service already stores area id under the`area` attribute  in the `params` object, so using that attribute name for consistency. cc: @gtempus 