### PR TITLE
GTC-3092:  Fetch 4.1 IDs During Save

### DIFF
--- a/app/Gruntfile.js
+++ b/app/Gruntfile.js
@@ -22,10 +22,10 @@ module.exports = (grunt) => {
         mochaTest: {
             unit: {
                 options: {
-                    timout: 10000,
+                    timeout: 10000,
                     reporter: 'spec',
                     quiet: false, // Optionally suppress output to standard out (defaults to false)
-                    clearRequireCache: true, // Optionally clear the require cache before running tests (defaults to false)
+                    clearRequireCache: false, // Optionally clear the require cache before running tests (defaults to false)
                 },
                 src: ['app/test/unit/**/*.test.js']
             },

--- a/app/src/adapters/dataApiAdminLookup.adapter.js
+++ b/app/src/adapters/dataApiAdminLookup.adapter.js
@@ -1,0 +1,53 @@
+const logger = require('logger');
+const axios = require('axios');
+const AdministrativeVersion = require('valueObjects/administrativeVersion');
+
+class DataApiAdminLookup {
+
+    static async findMatch(administrativeVersion) {
+        try {
+            const params = this.buildQueryParams(administrativeVersion);
+            const response = await this.performLookup(params);
+            return this.buildMatchedAdministrativeVersions(response);
+        } catch (e) {
+            logger.error(`[AREAS-V2-DataApiAdminLookup-Adapter] Failed to encode AdministrativeVersion: ${JSON.stringify(administrativeVersion)} \n response from DataApi Service was: ${JSON.stringify(e)}`, e);
+            return [];
+        }
+    }
+
+    static buildQueryParams(administrativeVersion) {
+        const { country, region, subregion } = administrativeVersion;
+
+        return {
+            admin_version: '4.1',
+            ...(country?.name && { country: country.name }),
+            ...(region?.name && { region: region.name }),
+            ...(subregion?.name && { subregion: subregion.name }),
+        };
+    }
+
+    static async performLookup(params) {
+        return axios.get(
+            '/political/id-lookup',
+            {
+                baseURL: 'https://data-api.globalforestwatch.org',
+                timeout: 3000,
+                headers: { 'Content-Type': 'application/json' },
+                params,
+            }
+        );
+    }
+
+    static buildMatchedAdministrativeVersions(response) {
+        return response?.data?.data?.matches.map((adminInfo) => new AdministrativeVersion(
+            {
+                provider: response.data.data.adminSource.toLocaleLowerCase().trim(),
+                version: response.data.data.adminVersion,
+                ...adminInfo,
+            }
+        ));
+    }
+
+}
+
+module.exports = DataApiAdminLookup;

--- a/app/src/entities/areaV2.entity.js
+++ b/app/src/entities/areaV2.entity.js
@@ -1,4 +1,5 @@
 const AdministrativeVersion = require('valueObjects/administrativeVersion');
+const AdminLookupService = require('services/adminLookup.service');
 
 class AreaEntity {
 
@@ -83,7 +84,7 @@ class AreaEntity {
      * Build and add (or update) an AdministrativeVersion entry in `areaModel.adminVersions`.
      * Will only proceed if the area is an administrative boundary.
      */
-    populateAdminVersions() {
+    async populateAdminVersions() {
         if (!this.isAdministrativeBoundary()) return;
 
         const adminVersion = AdministrativeVersion.build(
@@ -93,6 +94,11 @@ class AreaEntity {
         );
 
         this.addAdminVersion(adminVersion);
+
+        const gadm41AdminVersionMatches = await AdminLookupService.findMatch(adminVersion);
+        if (gadm41AdminVersionMatches?.length === 1) {
+            this.addAdminVersion(gadm41AdminVersionMatches.pop());
+        }
     }
 
     /**

--- a/app/src/models/area.modelV2.js
+++ b/app/src/models/area.modelV2.js
@@ -121,10 +121,10 @@ Area.statics.existsSavedAreaForGeostoreDataApi = async function existsSavedAreaF
 Area.plugin(mongooseHistory);
 Area.plugin(mongoosePaginate);
 
-Area.pre('validate', function (next) {
+Area.pre('validate', async function (next) {
     try {
         const areaEntity = new AreaEntity(this);
-        areaEntity.populateAdminVersions();
+        await areaEntity.populateAdminVersions();
     } catch (e) {
         logger.error(`[AREAS-V2-Model] Could not populate AdminVersions for userId: '${this.userId}' and Area name: '${this.name}'`, e);
     } finally {

--- a/app/src/services/adminLookup.service.js
+++ b/app/src/services/adminLookup.service.js
@@ -1,0 +1,11 @@
+const DataApiAdminLookup = require('adapters/dataApiAdminLookup.adapter');
+
+class AdminLookupService {
+
+    static async findMatch(administrativeVersion) {
+        return DataApiAdminLookup.findMatch(administrativeVersion);
+    }
+
+}
+
+module.exports = AdminLookupService;

--- a/app/src/valueObjects/administrativeVersion.js
+++ b/app/src/valueObjects/administrativeVersion.js
@@ -66,11 +66,11 @@ class AdministrativeVersion {
         this.version = version;
         this.geostore = geostore;
         this.country = country;
-        if (region) {
+        if (region && region.id) {
             this.region = region;
         }
 
-        if (subregion) {
+        if (subregion && subregion.id) {
             this.subregion = subregion;
         }
     }

--- a/app/test/e2e/v2/area-emails.spec.js
+++ b/app/test/e2e/v2/area-emails.spec.js
@@ -48,6 +48,21 @@ describe('V2 - Area emails', () => {
         // eslint-disable-next-line no-promise-executor-return
         const fake = sandbox.stub(MailService, 'sendMail').returns(new Promise((resolve) => resolve()));
 
+        nock('https://data-api.globalforestwatch.org')
+            .get('/political/id-lookup')
+            .query({
+                admin_version: '4.1',
+                country: 'Portugal area',
+            })
+            .reply(200, {
+                data: {
+                    adminSource: 'GADM',
+                    adminVersion: '4.1',
+                    matches: []
+                },
+                status: 'success'
+            });
+
         const response = await requester
             .post(`/api/v2/area`)
             .set('Authorization', 'Bearer abcd')

--- a/app/test/e2e/v2/create-area.spec.js
+++ b/app/test/e2e/v2/create-area.spec.js
@@ -218,6 +218,21 @@ describe('V2 - Create area', () => {
         it('Creating an area with custom env should be successful and have the correct env value', async () => {
             mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
 
+            nock('https://data-api.globalforestwatch.org')
+                .get('/political/id-lookup')
+                .query({
+                    admin_version: '4.1',
+                    country: 'Portugal area',
+                })
+                .reply(200, {
+                    data: {
+                        adminSource: 'GADM',
+                        adminVersion: '4.1',
+                        matches: []
+                    },
+                    status: 'success'
+                });
+
             const response = await requester
                 .post(`/api/v2/area`)
                 .set('Authorization', 'Bearer abcd')

--- a/app/test/e2e/v2/update-area.spec.js
+++ b/app/test/e2e/v2/update-area.spec.js
@@ -64,6 +64,21 @@ describe('V2 - Update area', () => {
     it('Updating an area while being logged in as a user that owns the area should return a 200 HTTP code and the updated area object', async () => {
         mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
 
+        nock('https://data-api.globalforestwatch.org')
+            .get('/political/id-lookup')
+            .query({
+                admin_version: '4.1',
+                country: 'Portugal area',
+            })
+            .reply(200, {
+                data: {
+                    adminSource: 'GADM',
+                    adminVersion: '4.1',
+                    matches: []
+                },
+                status: 'success'
+            });
+
         const testArea = await new Area(createArea({ userId: USERS.USER.id })).save();
 
         const response = await requester
@@ -121,6 +136,21 @@ describe('V2 - Update area', () => {
 
     it('Updating an area with a file while being logged in as a user that owns the area should upload the image to S3 and return a 200 HTTP code and the updated area object', async () => {
         mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
+
+        nock('https://data-api.globalforestwatch.org')
+            .get('/political/id-lookup')
+            .query({
+                admin_version: '4.1',
+                country: 'Portugal area',
+            })
+            .reply(200, {
+                data: {
+                    adminSource: 'GADM',
+                    adminVersion: '4.1',
+                    matches: []
+                },
+                status: 'success'
+            });
 
         const testArea = await new Area(createArea({ userId: USERS.USER.id })).save();
 
@@ -185,6 +215,21 @@ describe('V2 - Update area', () => {
 
     it('Updating an area with an env modifies the env', async () => {
         mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
+
+        nock('https://data-api.globalforestwatch.org')
+            .get('/political/id-lookup')
+            .query({
+                admin_version: '4.1',
+                country: 'Portugal area',
+            })
+            .reply(200, {
+                data: {
+                    adminSource: 'GADM',
+                    adminVersion: '4.1',
+                    matches: []
+                },
+                status: 'success'
+            });
 
         const testArea = await new Area(createArea({ userId: USERS.USER.id })).save();
 

--- a/app/test/unit/adapters/dataApiAminLookup.adapter.test.js
+++ b/app/test/unit/adapters/dataApiAminLookup.adapter.test.js
@@ -1,0 +1,297 @@
+/* eslint mocha/no-skipped-tests: "off", no-unused-vars: "off", no-unused-expressions: "off", mocha/no-setup-in-describe: "off" */
+const chai = require('chai');
+const sinon = require('sinon');
+const axios = require('axios');
+const logger = require('logger');
+const DataApiAdminLookup = require('adapters/dataApiAdminLookup.adapter');
+const AdministrativeVersion = require('valueObjects/administrativeVersion');
+
+const { expect } = chai;
+
+describe('Admin Lookup Adapter', () => {
+    let sandbox;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('Axios Integration', () => {
+        describe('Creating the Request', () => {
+            it('uses the Data API\'s Political ID Lookup endpoint', async () => {
+                const axiosGetStub = sandbox.stub(axios, 'get');
+                const gadm36AdminBoundary = AdministrativeVersion.build(
+                    null,
+                    ['Honduras', 'Francisco Morazán', 'Distrito Central'],
+                    ['HND', '8', '4']
+                );
+
+                await DataApiAdminLookup.findMatch(gadm36AdminBoundary);
+
+                sinon.assert.calledWith(
+                    axiosGetStub,
+                    sinon.match('/political/id-lookup'),
+                    sinon.match.any
+                );
+
+            });
+
+            it('sets the `admin_version` query parameter to \'4.1\'', async () => {
+                const axiosGetStub = sandbox.stub(axios, 'get');
+                const gadm36AdminBoundary = AdministrativeVersion.build(
+                    null,
+                    ['Honduras', 'Francisco Morazán', 'Distrito Central'],
+                    ['HND', '8', '4']
+                );
+
+                await DataApiAdminLookup.findMatch(gadm36AdminBoundary);
+
+                sinon.assert.calledWith(
+                    axiosGetStub,
+                    sinon.match.any,
+                    sinon.match({ params: sinon.match({ admin_version: '4.1' }) }),
+                );
+            });
+            context('Only Country is Provided', () => {
+                const gadm36AdminBoundaryCountryOnly = AdministrativeVersion.build(
+                    null,
+                    ['Honduras'],
+                    ['HND']
+                );
+                it('adds the `country` query parameter with the name of the country', async () => {
+                    const axiosGetStub = sandbox.stub(axios, 'get');
+
+                    await DataApiAdminLookup.findMatch(gadm36AdminBoundaryCountryOnly);
+
+                    sinon.assert.calledWith(
+                        axiosGetStub,
+                        sinon.match.any,
+                        sinon.match({ params: sinon.match({ country: 'Honduras' }) }),
+                    );
+                });
+                it('does NOT include the `region` query parameter', async () => {
+                    const axiosGetStub = sandbox.stub(axios, 'get');
+
+                    await DataApiAdminLookup.findMatch(gadm36AdminBoundaryCountryOnly);
+
+                    sinon.assert.calledWith(
+                        axiosGetStub,
+                        sinon.match.any,
+                        sinon.match((value) => !value.params.region, 'region should not be part of the query parameters')
+                    );
+                });
+                it('does NOT include the `subregion` query parameter', async () => {
+                    const axiosGetStub = sandbox.stub(axios, 'get');
+
+                    await DataApiAdminLookup.findMatch(gadm36AdminBoundaryCountryOnly);
+
+                    sinon.assert.calledWith(
+                        axiosGetStub,
+                        sinon.match.any,
+                        sinon.match((value) => !value.params.subregion, 'subregion should not be part of the query parameters')
+                    );
+                });
+            });
+            context('Only Country and Region are Provided', () => {
+                const gadm36AdminBoundaryCountryAndRegionOnly = AdministrativeVersion.build(
+                    null,
+                    ['Honduras', 'Francisco Morazán'],
+                    ['HND', '8']
+                );
+
+                it('adds the `country` query parameter with the name of the country', async () => {
+                    const axiosGetStub = sandbox.stub(axios, 'get');
+
+                    await DataApiAdminLookup.findMatch(gadm36AdminBoundaryCountryAndRegionOnly);
+
+                    sinon.assert.calledWith(
+                        axiosGetStub,
+                        sinon.match.any,
+                        sinon.match({ params: sinon.match({ country: 'Honduras' }) }),
+                    );
+                });
+                it('adds the `region` query parameter with the name of the region', async () => {
+                    const axiosGetStub = sandbox.stub(axios, 'get');
+
+                    await DataApiAdminLookup.findMatch(gadm36AdminBoundaryCountryAndRegionOnly);
+
+                    sinon.assert.calledWith(
+                        axiosGetStub,
+                        sinon.match.any,
+                        sinon.match({ params: sinon.match({ region: 'Francisco Morazán' }) }),
+                    );
+                });
+                it('does NOT include the `subregion` query parameter ', async () => {
+                    const axiosGetStub = sandbox.stub(axios, 'get');
+
+                    await DataApiAdminLookup.findMatch(gadm36AdminBoundaryCountryAndRegionOnly);
+
+                    sinon.assert.calledWith(
+                        axiosGetStub,
+                        sinon.match.any,
+                        sinon.match((value) => !value.params.subregion, 'subregion should not be part of the query parameters')
+                    );
+                });
+            });
+            context('Country, Region, and Subregion are Provided', () => {
+                const gadm36AdminBoundaryAllParts = AdministrativeVersion.build(
+                    null,
+                    ['Honduras', 'Francisco Morazán', 'Distrito Central'],
+                    ['HND', '8', '4']
+                );
+
+                it('adds the `country` query parameter with the name of the country', async () => {
+                    const axiosGetStub = sandbox.stub(axios, 'get');
+
+                    await DataApiAdminLookup.findMatch(gadm36AdminBoundaryAllParts);
+
+                    sinon.assert.calledWith(
+                        axiosGetStub,
+                        sinon.match.any,
+                        sinon.match({ params: sinon.match({ country: 'Honduras' }) }),
+                    );
+                });
+                it('adds the `region` query parameter with the name of the region', async () => {
+                    const axiosGetStub = sandbox.stub(axios, 'get');
+
+                    await DataApiAdminLookup.findMatch(gadm36AdminBoundaryAllParts);
+                    sinon.assert.calledWith(
+                        axiosGetStub,
+                        sinon.match.any,
+                        sinon.match({ params: sinon.match({ region: 'Francisco Morazán' }) })
+                    );
+                });
+                it('adds the `subregion` query parameter with the name of the region', async () => {
+                    const axiosGetStub = sandbox.stub(axios, 'get');
+
+                    await DataApiAdminLookup.findMatch(gadm36AdminBoundaryAllParts);
+
+                    sinon.assert.calledWith(
+                        axiosGetStub,
+                        sinon.match.any,
+                        sinon.match({ params: sinon.match({ subregion: 'Distrito Central' }) }),
+                    );
+                });
+            });
+        });
+
+        describe('Transforming the Response', () => {
+            context('Only One Match is Made', () => {
+                it('returns an array with the one encoded match', async () => {
+                    const axiosGetStub = sandbox.stub(axios, 'get');
+                    const mockResponse = {
+                        data: {
+                            data: {
+                                adminSource: 'GADM',
+                                adminVersion: '4.1',
+                                matches: [
+                                    {
+                                        country: { id: 'HND', name: 'Honduras' },
+                                        region: { id: '8', name: 'Francisco Morazán' },
+                                        subregion: { id: null, name: null }
+                                    }
+                                ]
+                            },
+                            status: 'success'
+                        }
+                    };
+                    axiosGetStub.resolves(JSON.parse(JSON.stringify(mockResponse)));
+
+                    const result = await DataApiAdminLookup.findMatch(new AdministrativeVersion());
+
+                    expect(result).to.be.an('array').with.length(1);
+                    expect(JSON.parse(JSON.stringify(result[0]))).to.deep.include({
+                        provider: 'gadm',
+                        version: '4.1',
+                        country: { id: 'HND', name: 'Honduras' },
+                        region: { id: '8', name: 'Francisco Morazán' },
+                    });
+                });
+            });
+            context('More Than One Match is Made', () => {
+                it('returns an array with all the encoded matches', async () => {
+                    const axiosGetStub = sandbox.stub(axios, 'get');
+                    const mockResponse = {
+                        data: {
+                            data: {
+                                adminSource: 'GADM',
+                                adminVersion: '4.1',
+                                matches: [
+                                    {
+                                        country: { id: 'HND', name: 'Honduras' },
+                                        region: { id: '8', name: 'Francisco Morazán' },
+                                        subregion: { id: null, name: null }
+                                    },
+                                    {
+                                        country: { id: 'KEN', name: 'Kenya' },
+                                        region: { id: '15', name: 'Kirinyaga' },
+                                        subregion: { id: '1', name: 'Gichugu' },
+                                    },
+                                ]
+                            },
+                            status: 'success',
+                        }
+                    };
+
+                    axiosGetStub.resolves(JSON.parse(JSON.stringify(mockResponse)));
+
+                    const result = await DataApiAdminLookup.findMatch(new AdministrativeVersion());
+
+                    expect(result).to.be.an('array').with.length(2);
+                });
+
+            });
+            context('No Match is Made', () => {
+                it('returns an empty array', async () => {
+                    const axiosGetStub = sandbox.stub(axios, 'get');
+                    const mockResponse = {
+                        data: {
+                            data: {
+                                adminSource: 'GADM',
+                                adminVersion: '4.1',
+                                matches: []
+                            },
+                            status: 'success',
+                        }
+                    };
+
+                    axiosGetStub.resolves(JSON.parse(JSON.stringify(mockResponse)));
+
+                    const result = await DataApiAdminLookup.findMatch(new AdministrativeVersion());
+
+                    expect(result).to.be.an('array').with.length(0);
+                });
+            });
+        });
+
+        describe('Errors', () => {
+            context('Axios Throws an Exception', () => {
+                it('logs the error message', async () => {
+                    sandbox.stub(logger, 'error');
+                    sandbox.stub(axios, 'get').throws(new Error('Test Error'));
+
+                    await DataApiAdminLookup.findMatch(new AdministrativeVersion());
+
+                    sinon.assert.calledOnce(logger.error);
+                    sinon.assert.calledWith(
+                        logger.error,
+                        sinon.match('[AREAS-V2-DataApiAdminLookup-Adapter] Failed to encode AdministrativeVersion'),
+                        sinon.match.has('message', 'Test Error')
+                    );
+
+                });
+                it('returns an empty array', async () => {
+                    sandbox.stub(logger, 'error');
+                    sandbox.stub(axios, 'get').throws(new Error('Test Error'));
+
+                    const result = await DataApiAdminLookup.findMatch(new AdministrativeVersion());
+
+                    expect(result).to.be.an('array').with.length(0);
+                });
+            });
+        });
+    });
+});

--- a/app/test/unit/entities/areaV2.entity.test.js
+++ b/app/test/unit/entities/areaV2.entity.test.js
@@ -1,13 +1,73 @@
 /* eslint mocha/no-skipped-tests: "off", no-unused-vars: "off", no-unused-expressions: "off" */
 const chai = require('chai');
+const sinon = require('sinon');
 const AreaModel = require('models/area.modelV2');
 const AreaEntity = require('entities/areaV2.entity');
 const AdministrativeVersion = require('valueObjects/administrativeVersion');
+const AdminLookupService = require('services/adminLookup.service');
 
 const { expect } = chai;
 
 describe('Area Entity V2', () => {
+    describe('Adding a GADM 4.1 AdministrativeVersion', () => {
+        let sandbox;
+
+        before(() => {
+            sandbox = sinon.createSandbox();
+            sandbox.stub(AdminLookupService, 'findMatch').resolves([
+                new AdministrativeVersion({
+                    provider: 'gadm',
+                    version: '4.1',
+                    country: { id: 'HND', name: 'Honduras' },
+                    region: { id: '8', name: 'Francisco Morazán' },
+                    subregion: { id: '4', name: 'Distrito Central' }
+                })
+            ]);
+        });
+
+        after(() => {
+            sandbox.restore();
+        });
+
+        describe('The AdministrativeVersion is Found', () => {
+            it('adds the AdministrativeVersion to the collection of adminVersions', async () => {
+                const areaData = {
+                    name: 'Distrito Central, Francisco Morazán, Honduras',
+                    geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+                    admin: {
+                        adm0: 'HND',
+                        adm1: 8,
+                        adm2: 4,
+                    }
+                };
+                const areaModel = new AreaModel(areaData);
+                const areaEntity = new AreaEntity(areaModel);
+
+                await areaEntity.populateAdminVersions(AdminLookupService);
+
+                expect(areaModel.toObject().adminVersions[1]).to.deep.include({
+                    provider: 'gadm',
+                    version: '4.1',
+                    country: { id: 'HND', name: 'Honduras' },
+                    region: { id: '8', name: 'Francisco Morazán' },
+                    subregion: { id: '4', name: 'Distrito Central' }
+                });
+            });
+        });
+    });
+
     describe('Legacy GADM v3.6 Areas', () => {
+        let sandbox;
+
+        before(() => {
+            sandbox = sinon.createSandbox();
+            sandbox.stub(AdminLookupService, 'findMatch').resolves([]);
+        });
+
+        after(() => {
+            sandbox.restore();
+        });
+
         describe('Administrative Boundary Versions', () => {
             describe('An Area That Does NOT Have A History Of Versions', () => {
                 describe('And Is An Administrative Boundary', () => {
@@ -22,34 +82,34 @@ describe('Area Entity V2', () => {
                             }
                         };
 
-                        it('creates an adminVersions collection', () => {
+                        it('creates an adminVersions collection', async () => {
                             const area = new AreaModel(areaDataWithAdmin);
                             const areaEntity = new AreaEntity(area);
-                            areaEntity.populateAdminVersions();
+                            await areaEntity.populateAdminVersions();
                             expect(area.adminVersions).to.be.instanceof(Array);
                         });
 
-                        it('creates an AdministrativeVersion and adds it to the adminVersion collection', () => {
+                        it('creates an AdministrativeVersion and adds it to the adminVersion collection', async () => {
                             const area = new AreaModel(areaDataWithAdmin);
                             const areaEntity = new AreaEntity(area);
-                            areaEntity.populateAdminVersions();
+                            await areaEntity.populateAdminVersions();
                             expect(area.adminVersions).to.not.be.empty;
                         });
 
                         describe('But Does Not Have An Area Name', () => {
                             const areaDataWithAdminButNoName = { ...areaDataWithAdmin, name: '' };
 
-                            it('creates an adminVersions collection', () => {
+                            it('creates an adminVersions collection', async () => {
                                 const area = new AreaModel(areaDataWithAdminButNoName);
                                 const areaEntity = new AreaEntity(area);
-                                areaEntity.populateAdminVersions();
+                                await areaEntity.populateAdminVersions();
                                 expect(area.adminVersions).to.be.instanceof(Array);
                             });
 
-                            it('creates an AdministrativeVersion and adds it to the adminVersion collection', () => {
+                            it('creates an AdministrativeVersion and adds it to the adminVersion collection', async () => {
                                 const area = new AreaModel(areaDataWithAdminButNoName);
                                 const areaEntity = new AreaEntity(area);
-                                areaEntity.populateAdminVersions();
+                                await areaEntity.populateAdminVersions();
                                 expect(area.adminVersions).to.not.be.empty;
                             });
                         });
@@ -66,34 +126,34 @@ describe('Area Entity V2', () => {
                             }
                         };
 
-                        it('creates an adminVersions collection', () => {
+                        it('creates an adminVersions collection', async () => {
                             const area = new AreaModel(areaDataWithIso);
                             const areaEntity = new AreaEntity(area);
-                            areaEntity.populateAdminVersions();
+                            await areaEntity.populateAdminVersions();
                             expect(area.adminVersions).to.be.instanceof(Array);
                         });
 
-                        it('creates an AdministrativeVersion and adds it to the adminVersion collection', () => {
+                        it('creates an AdministrativeVersion and adds it to the adminVersion collection', async () => {
                             const area = new AreaModel(areaDataWithIso);
                             const areaEntity = new AreaEntity(area);
-                            areaEntity.populateAdminVersions();
+                            await areaEntity.populateAdminVersions();
                             expect(area.adminVersions).to.not.be.empty;
                         });
 
                         describe('Has a Name But It Is Missing Its Country Part', () => {
                             const areaDataWithIsoButNameWithNoCountry = { ...areaDataWithIso, name: 'Distrito Central, Francisco Morazán,' };
 
-                            it('creates an adminVersions collection', () => {
+                            it('creates an adminVersions collection', async () => {
                                 const area = new AreaModel(areaDataWithIsoButNameWithNoCountry);
                                 const areaEntity = new AreaEntity(area);
-                                areaEntity.populateAdminVersions();
+                                await areaEntity.populateAdminVersions();
                                 expect(area.adminVersions).to.be.instanceof(Array);
                             });
 
-                            it('creates an AdministrativeVersion and adds it to the adminVersion collection', () => {
+                            it('creates an AdministrativeVersion and adds it to the adminVersion collection', async () => {
                                 const area = new AreaModel(areaDataWithIsoButNameWithNoCountry);
                                 const areaEntity = new AreaEntity(area);
-                                areaEntity.populateAdminVersions();
+                                await areaEntity.populateAdminVersions();
                                 expect(area.adminVersions).to.not.be.empty;
                             });
                         });
@@ -101,17 +161,17 @@ describe('Area Entity V2', () => {
                         describe('But Does Not Have An Area Name', () => {
                             const areaDataWithIsoButNoName = { ...areaDataWithIso, name: '' };
 
-                            it('creates an adminVersions collection', () => {
+                            it('creates an adminVersions collection', async () => {
                                 const area = new AreaModel(areaDataWithIsoButNoName);
                                 const areaEntity = new AreaEntity(area);
-                                areaEntity.populateAdminVersions();
+                                await areaEntity.populateAdminVersions();
                                 expect(area.adminVersions).to.be.instanceof(Array);
                             });
 
-                            it('creates an AdministrativeVersion and adds it to the adminVersion collection', () => {
+                            it('creates an AdministrativeVersion and adds it to the adminVersion collection', async () => {
                                 const area = new AreaModel(areaDataWithIsoButNoName);
                                 const areaEntity = new AreaEntity(area);
-                                areaEntity.populateAdminVersions();
+                                await areaEntity.populateAdminVersions();
                                 expect(area.adminVersions).to.not.be.empty;
                             });
                         });
@@ -119,7 +179,7 @@ describe('Area Entity V2', () => {
                 });
 
                 describe('And Is NOT An Administrative Boundary', () => {
-                    it('does not create an adminVersions collection', () => {
+                    it('does not create an adminVersions collection', async () => {
                         const noAdminArea = {
                             name: 'Distrito Central, Francisco Morazán, Honduras',
                             geostore: 'abcf7041e2fbc5e8e7774178157ababe',
@@ -127,7 +187,7 @@ describe('Area Entity V2', () => {
 
                         const area = new AreaModel(noAdminArea);
                         const areaEntity = new AreaEntity(area);
-                        areaEntity.populateAdminVersions();
+                        await areaEntity.populateAdminVersions();
                         expect(area.adminVersions).to.be.empty;
                     });
                 });
@@ -162,26 +222,26 @@ describe('Area Entity V2', () => {
                         }
                     };
 
-                    it('does NOT add a duplicate AdministrativeVersion to the adminVersions collection', () => {
+                    it('does NOT add a duplicate AdministrativeVersion to the adminVersions collection', async () => {
                         const area = new AreaModel(areaDataWithAdminVersions);
                         const areaEntity = new AreaEntity(area);
 
-                        areaEntity.populateAdminVersions();
+                        await areaEntity.populateAdminVersions();
 
                         expect(area.adminVersions).to.have.length(1);
                     });
 
-                    it('updates the geostore', () => {
+                    it('updates the geostore', async () => {
                         areaDataWithAdminVersions.geostore = 'ffff000000000000000000000000ffff';
                         const area = new AreaModel(areaDataWithAdminVersions);
                         const areaEntity = new AreaEntity(area);
 
-                        areaEntity.populateAdminVersions();
+                        await areaEntity.populateAdminVersions();
 
                         expect(area.adminVersions[0]).to.have.property('geostore', 'ffff000000000000000000000000ffff');
                     });
 
-                    it('updates the country', () => {
+                    it('updates the country', async () => {
                         areaDataWithAdminVersions.name = 'Altamira, Pará, Brazil';
                         areaDataWithAdminVersions.iso = {
                             country: 'BRA',
@@ -191,12 +251,12 @@ describe('Area Entity V2', () => {
                         const area = new AreaModel(areaDataWithAdminVersions);
                         const areaEntity = new AreaEntity(area);
 
-                        areaEntity.populateAdminVersions();
+                        await areaEntity.populateAdminVersions();
                         expect(area.adminVersions[0]).to.have.deep.property('country', { id: 'BRA', name: 'Brazil' });
                     });
 
                     describe('Updating A Region', () => {
-                        it('updates the region when it is defined', () => {
+                        it('updates the region when it is defined', async () => {
                             areaDataWithAdminVersions.name = 'Pará, Brazil';
                             areaDataWithAdminVersions.iso = {
                                 country: 'BRA',
@@ -205,11 +265,11 @@ describe('Area Entity V2', () => {
                             const area = new AreaModel(areaDataWithAdminVersions);
                             const areaEntity = new AreaEntity(area);
 
-                            areaEntity.populateAdminVersions();
+                            await areaEntity.populateAdminVersions();
                             expect(area.adminVersions[0]).to.have.deep.property('region', { id: '14', name: 'Pará' });
                         });
 
-                        it('removes a region when it is NOT defined', () => {
+                        it('removes a region when it is NOT defined', async () => {
                             areaDataWithAdminVersions.name = 'Brazil';
                             areaDataWithAdminVersions.iso = {
                                 country: 'BRA',
@@ -217,14 +277,14 @@ describe('Area Entity V2', () => {
                             const area = new AreaModel(areaDataWithAdminVersions);
                             const areaEntity = new AreaEntity(area);
 
-                            areaEntity.populateAdminVersions();
+                            await areaEntity.populateAdminVersions();
 
                             expect(area.adminVersions[0]).to.not.have.property('region');
                         });
                     });
 
                     describe('Updating a Subregion', () => {
-                        it('updates the subregion when it is defined', () => {
+                        it('updates the subregion when it is defined', async () => {
                             areaDataWithAdminVersions.name = 'Altamira, Pará, Brazil';
                             areaDataWithAdminVersions.iso = {
                                 country: 'BRA',
@@ -234,14 +294,14 @@ describe('Area Entity V2', () => {
                             const area = new AreaModel(areaDataWithAdminVersions);
                             const areaEntity = new AreaEntity(area);
 
-                            areaEntity.populateAdminVersions();
+                            await areaEntity.populateAdminVersions();
                             expect(area.adminVersions[0]).to.have.deep.property('subregion', {
                                 id: '8',
                                 name: 'Altamira'
                             });
                         });
 
-                        it('removes a subregion when it is NOT defined', () => {
+                        it('removes a subregion when it is NOT defined', async () => {
                             areaDataWithAdminVersions.name = 'Pará, Brazil';
                             areaDataWithAdminVersions.iso = {
                                 country: 'BRA',
@@ -250,7 +310,7 @@ describe('Area Entity V2', () => {
                             const area = new AreaModel(areaDataWithAdminVersions);
                             const areaEntity = new AreaEntity(area);
 
-                            areaEntity.populateAdminVersions();
+                            await areaEntity.populateAdminVersions();
                             expect(area.adminVersions[0]).to.not.have.property('subregion');
                         });
                     });
@@ -268,45 +328,45 @@ describe('Area Entity V2', () => {
                             }
                         };
 
-                        it('adds an AdministrativeVersion to the adminVersions collection', () => {
+                        it('adds an AdministrativeVersion to the adminVersions collection', async () => {
                             const area = new AreaModel(areaData);
                             const areaEntity = new AreaEntity(area);
-                            areaEntity.populateAdminVersions();
+                            await areaEntity.populateAdminVersions();
                             expect(area.adminVersions[0].toJSON()).to.be.instanceof(Object);
                         });
 
-                        it('sets the provider to `gadm`', () => {
+                        it('sets the provider to `gadm`', async () => {
                             const area = new AreaModel(areaData);
                             const areaEntity = new AreaEntity(area);
 
-                            areaEntity.populateAdminVersions();
+                            await areaEntity.populateAdminVersions();
 
                             expect(area.adminVersions[0].toObject()).to.have.deep.property('provider', 'gadm');
                         });
 
-                        it('set the version to `3.6`', () => {
+                        it('set the version to `3.6`', async () => {
                             const area = new AreaModel(areaData);
                             const areaEntity = new AreaEntity(area);
 
-                            areaEntity.populateAdminVersions();
+                            await areaEntity.populateAdminVersions();
 
                             expect(area.adminVersions[0].toObject()).to.have.deep.property('version', '3.6');
                         });
 
-                        it('includes the geostore', () => {
+                        it('includes the geostore', async () => {
                             const area = new AreaModel(areaData);
                             const areaEntity = new AreaEntity(area);
 
-                            areaEntity.populateAdminVersions();
+                            await areaEntity.populateAdminVersions();
 
                             expect(area.adminVersions[0].toObject()).to.have.deep.property('geostore', 'abcf7041e2fbc5e8e7774178157ababe');
                         });
 
-                        it('includes the country', () => {
+                        it('includes the country', async () => {
                             const area = new AreaModel(areaData);
                             const areaEntity = new AreaEntity(area);
 
-                            areaEntity.populateAdminVersions();
+                            await areaEntity.populateAdminVersions();
 
                             expect(area.adminVersions[0].toObject()).to.have.deep.property('country', {
                                 id: 'HND',
@@ -315,11 +375,11 @@ describe('Area Entity V2', () => {
                         });
 
                         describe('Including A Region', () => {
-                            it('includes the region when it is defined', () => {
+                            it('includes the region when it is defined', async () => {
                                 const area = new AreaModel(areaData);
                                 const areaEntity = new AreaEntity(area);
 
-                                areaEntity.populateAdminVersions();
+                                await areaEntity.populateAdminVersions();
 
                                 expect(area.adminVersions[0].toObject()).to.have.deep.property(
                                     'region',
@@ -327,7 +387,7 @@ describe('Area Entity V2', () => {
                                 );
                             });
 
-                            it('does NOT include a region when it is NOT defined', () => {
+                            it('does NOT include a region when it is NOT defined', async () => {
                                 const countryOnly = {
                                     name: 'Honduras',
                                     geostore: 'abcf7041e2fbc5e8e7774178157ababe',
@@ -341,18 +401,18 @@ describe('Area Entity V2', () => {
                                 const area = new AreaModel(countryOnly);
                                 const areaEntity = new AreaEntity(area);
 
-                                areaEntity.populateAdminVersions();
+                                await areaEntity.populateAdminVersions();
 
                                 expect(area.adminVersions[0].toObject()).to.not.have.deep.property('region');
                             });
                         });
 
                         describe('Including a Subregion', () => {
-                            it('includes the subregion when it is defined', () => {
+                            it('includes the subregion when it is defined', async () => {
                                 const area = new AreaModel(areaData);
                                 const areaEntity = new AreaEntity(area);
 
-                                areaEntity.populateAdminVersions();
+                                await areaEntity.populateAdminVersions();
 
                                 expect(area.adminVersions[0].toObject()).to.have.deep.property(
                                     'subregion',
@@ -360,7 +420,7 @@ describe('Area Entity V2', () => {
                                 );
                             });
 
-                            it('does NOT include a subregion when it is NOT defined', () => {
+                            it('does NOT include a subregion when it is NOT defined', async () => {
                                 const countryAndRegionOnly = {
                                     name: 'Francisco Morazán, Honduras',
                                     geostore: 'abcf7041e2fbc5e8e7774178157ababe',
@@ -373,7 +433,7 @@ describe('Area Entity V2', () => {
                                 const area = new AreaModel(countryAndRegionOnly);
                                 const areaEntity = new AreaEntity(area);
 
-                                areaEntity.populateAdminVersions();
+                                await areaEntity.populateAdminVersions();
 
                                 expect(area.adminVersions[0].toObject()).to.not.have.deep.property('subregion');
                             });
@@ -391,45 +451,45 @@ describe('Area Entity V2', () => {
                             }
                         };
 
-                        it('adds an AdministrativeVersion to the adminVersions collection', () => {
+                        it('adds an AdministrativeVersion to the adminVersions collection', async () => {
                             const area = new AreaModel(areaDataWithIso);
                             const areaEntity = new AreaEntity(area);
-                            areaEntity.populateAdminVersions();
+                            await areaEntity.populateAdminVersions();
                             expect(area.adminVersions[0].toJSON()).to.be.instanceof(Object);
                         });
 
-                        it('sets the provider to `gadm`', () => {
+                        it('sets the provider to `gadm`', async () => {
                             const area = new AreaModel(areaDataWithIso);
                             const areaEntity = new AreaEntity(area);
 
-                            areaEntity.populateAdminVersions();
+                            await areaEntity.populateAdminVersions();
 
                             expect(area.adminVersions[0].toObject()).to.have.deep.property('provider', 'gadm');
                         });
 
-                        it('set the version to `3.6`', () => {
+                        it('set the version to `3.6`', async () => {
                             const area = new AreaModel(areaDataWithIso);
                             const areaEntity = new AreaEntity(area);
 
-                            areaEntity.populateAdminVersions();
+                            await areaEntity.populateAdminVersions();
 
                             expect(area.adminVersions[0].toObject()).to.have.deep.property('version', '3.6');
                         });
 
-                        it('includes the geostore', () => {
+                        it('includes the geostore', async () => {
                             const area = new AreaModel(areaDataWithIso);
                             const areaEntity = new AreaEntity(area);
 
-                            areaEntity.populateAdminVersions();
+                            await areaEntity.populateAdminVersions();
 
                             expect(area.adminVersions[0].toObject()).to.have.deep.property('geostore', 'abcf7041e2fbc5e8e7774178157ababe');
                         });
 
-                        it('includes the country', () => {
+                        it('includes the country', async () => {
                             const area = new AreaModel(areaDataWithIso);
                             const areaEntity = new AreaEntity(area);
 
-                            areaEntity.populateAdminVersions();
+                            await areaEntity.populateAdminVersions();
 
                             expect(area.adminVersions[0].toObject()).to.have.deep.property('country', {
                                 id: 'HND',
@@ -438,11 +498,11 @@ describe('Area Entity V2', () => {
                         });
 
                         describe('Including A Region', () => {
-                            it('includes the region when it is defined', () => {
+                            it('includes the region when it is defined', async () => {
                                 const area = new AreaModel(areaDataWithIso);
                                 const areaEntity = new AreaEntity(area);
 
-                                areaEntity.populateAdminVersions();
+                                await areaEntity.populateAdminVersions();
 
                                 expect(area.adminVersions[0].toObject()).to.have.deep.property(
                                     'region',
@@ -450,7 +510,7 @@ describe('Area Entity V2', () => {
                                 );
                             });
 
-                            it('does NOT include a region when it is NOT defined', () => {
+                            it('does NOT include a region when it is NOT defined', async () => {
                                 const countryOnlyWithIso = {
                                     name: 'Honduras',
                                     geostore: 'abcf7041e2fbc5e8e7774178157ababe',
@@ -462,18 +522,18 @@ describe('Area Entity V2', () => {
                                 const area = new AreaModel(countryOnlyWithIso);
                                 const areaEntity = new AreaEntity(area);
 
-                                areaEntity.populateAdminVersions();
+                                await areaEntity.populateAdminVersions();
 
                                 expect(area.adminVersions[0].toObject()).to.not.have.deep.property('region');
                             });
                         });
 
                         describe('Including a Subregion', () => {
-                            it('includes the subregion when it is defined', () => {
+                            it('includes the subregion when it is defined', async () => {
                                 const area = new AreaModel(areaDataWithIso);
                                 const areaEntity = new AreaEntity(area);
 
-                                areaEntity.populateAdminVersions();
+                                await areaEntity.populateAdminVersions();
 
                                 expect(area.adminVersions[0].toObject()).to.have.deep.property(
                                     'subregion',
@@ -481,7 +541,7 @@ describe('Area Entity V2', () => {
                                 );
                             });
 
-                            it('does NOT include a subregion when it is NOT defined', () => {
+                            it('does NOT include a subregion when it is NOT defined', async () => {
                                 const countryAndRegionOnlyWithIso = {
                                     name: 'Francisco Morazán, Honduras',
                                     geostore: 'abcf7041e2fbc5e8e7774178157ababe',
@@ -494,7 +554,7 @@ describe('Area Entity V2', () => {
                                 const area = new AreaModel(countryAndRegionOnlyWithIso);
                                 const areaEntity = new AreaEntity(area);
 
-                                areaEntity.populateAdminVersions();
+                                await areaEntity.populateAdminVersions();
 
                                 expect(area.adminVersions[0].toObject()).to.not.have.deep.property('subregion');
                             });
@@ -503,45 +563,45 @@ describe('Area Entity V2', () => {
                         describe('But Has A Name That is Missing Its Country', () => { // example from a real Area in production
                             const areaDataWithIsoButMissingCountryInName = { ...areaDataWithIso, name: 'Distrito Central, Francisco Morazán,' };
 
-                            it('adds an AdministrativeVersion to the adminVersions collection', () => {
+                            it('adds an AdministrativeVersion to the adminVersions collection', async () => {
                                 const area = new AreaModel(areaDataWithIsoButMissingCountryInName);
                                 const areaEntity = new AreaEntity(area);
-                                areaEntity.populateAdminVersions();
+                                await areaEntity.populateAdminVersions();
                                 expect(area.adminVersions[0].toJSON()).to.be.instanceof(Object);
                             });
 
-                            it('sets the provider to `gadm`', () => {
+                            it('sets the provider to `gadm`', async () => {
                                 const area = new AreaModel(areaDataWithIsoButMissingCountryInName);
                                 const areaEntity = new AreaEntity(area);
 
-                                areaEntity.populateAdminVersions();
+                                await areaEntity.populateAdminVersions();
 
                                 expect(area.adminVersions[0].toObject()).to.have.deep.property('provider', 'gadm');
                             });
 
-                            it('set the version to `3.6`', () => {
+                            it('set the version to `3.6`', async () => {
                                 const area = new AreaModel(areaDataWithIsoButMissingCountryInName);
                                 const areaEntity = new AreaEntity(area);
 
-                                areaEntity.populateAdminVersions();
+                                await areaEntity.populateAdminVersions();
 
                                 expect(area.adminVersions[0].toObject()).to.have.deep.property('version', '3.6');
                             });
 
-                            it('includes the geostore', () => {
+                            it('includes the geostore', async () => {
                                 const area = new AreaModel(areaDataWithIsoButMissingCountryInName);
                                 const areaEntity = new AreaEntity(area);
 
-                                areaEntity.populateAdminVersions();
+                                await areaEntity.populateAdminVersions();
 
                                 expect(area.adminVersions[0].toObject()).to.have.deep.property('geostore', 'abcf7041e2fbc5e8e7774178157ababe');
                             });
 
-                            it('includes the country with an empty name', () => {
+                            it('includes the country with an empty name', async () => {
                                 const area = new AreaModel(areaDataWithIsoButMissingCountryInName);
                                 const areaEntity = new AreaEntity(area);
 
-                                areaEntity.populateAdminVersions();
+                                await areaEntity.populateAdminVersions();
 
                                 expect(area.adminVersions[0].toObject()).to.have.deep.property('country', {
                                     id: 'HND',
@@ -550,11 +610,11 @@ describe('Area Entity V2', () => {
                             });
 
                             describe('Including A Region', () => {
-                                it('includes the region when it is defined', () => {
+                                it('includes the region when it is defined', async () => {
                                     const area = new AreaModel(areaDataWithIsoButMissingCountryInName);
                                     const areaEntity = new AreaEntity(area);
 
-                                    areaEntity.populateAdminVersions();
+                                    await areaEntity.populateAdminVersions();
 
                                     expect(area.adminVersions[0].toObject()).to.have.deep.property(
                                         'region',
@@ -562,7 +622,7 @@ describe('Area Entity V2', () => {
                                     );
                                 });
 
-                                it('does NOT include a region when it is NOT defined', () => {
+                                it('does NOT include a region when it is NOT defined', async () => {
                                     const countryOnlyWithIso = {
                                         name: 'Honduras',
                                         geostore: 'abcf7041e2fbc5e8e7774178157ababe',
@@ -574,18 +634,18 @@ describe('Area Entity V2', () => {
                                     const area = new AreaModel(countryOnlyWithIso);
                                     const areaEntity = new AreaEntity(area);
 
-                                    areaEntity.populateAdminVersions();
+                                    await areaEntity.populateAdminVersions();
 
                                     expect(area.adminVersions[0].toObject()).to.not.have.deep.property('region');
                                 });
                             });
 
                             describe('Including a Subregion', () => {
-                                it('includes the subregion when it is defined', () => {
+                                it('includes the subregion when it is defined', async () => {
                                     const area = new AreaModel(areaDataWithIsoButMissingCountryInName);
                                     const areaEntity = new AreaEntity(area);
 
-                                    areaEntity.populateAdminVersions();
+                                    await areaEntity.populateAdminVersions();
 
                                     expect(area.adminVersions[0].toObject()).to.have.deep.property(
                                         'subregion',
@@ -593,7 +653,7 @@ describe('Area Entity V2', () => {
                                     );
                                 });
 
-                                it('does NOT include a subregion when it is NOT defined', () => {
+                                it('does NOT include a subregion when it is NOT defined', async () => {
                                     const countryAndRegionOnlyWithIso = {
                                         name: 'Francisco Morazán, Honduras',
                                         geostore: 'abcf7041e2fbc5e8e7774178157ababe',
@@ -606,7 +666,7 @@ describe('Area Entity V2', () => {
                                     const area = new AreaModel(countryAndRegionOnlyWithIso);
                                     const areaEntity = new AreaEntity(area);
 
-                                    areaEntity.populateAdminVersions();
+                                    await areaEntity.populateAdminVersions();
 
                                     expect(area.adminVersions[0].toObject()).to.not.have.deep.property('subregion');
                                 });

--- a/app/test/unit/model/area.modelV2.test.js
+++ b/app/test/unit/model/area.modelV2.test.js
@@ -6,6 +6,7 @@ const logger = require('logger');
 
 const AreaModel = require('models/area.modelV2');
 const AreaEntity = require('entities/areaV2.entity');
+const AdminLookupService = require('services/adminLookup.service');
 
 const { expect } = chai;
 
@@ -20,11 +21,14 @@ describe('Area Model V2', () => {
             useNewUrlParser: true,
             useUnifiedTopology: true,
         });
+
+        sinon.stub(AdminLookupService, 'findMatch').resolves([]);
     });
 
     after(async () => {
         await mongoose.connection.close();
         await mongoServer.stop();
+        sinon.restore();
     });
 
     beforeEach(async () => {

--- a/app/test/unit/serializers/area.serializerV2.test.js
+++ b/app/test/unit/serializers/area.serializerV2.test.js
@@ -22,17 +22,17 @@ describe('Area Serializer V2', () => {
                 adm1: 8,
                 adm2: 4,
             },
-            adminVersions: [
-                {
-                    provider: 'gadm',
-                    version: '3.6',
-                    geostore: 'abcf7041e2fbc5e8e7774178157ababe',
-                    country: { id: 'HND', name: 'Honduras' },
-                    region: { id: '8', name: 'Francisco Morazán' },
-                    subregion: { id: '4', name: 'Distrito Central' },
-                }
-            ]
-        };
+        adminVersions: [
+            {
+                provider: 'gadm',
+                version: '3.6',
+                geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+                country: { id: 'HND', name: 'Honduras' },
+                region: { id: '8', name: 'Francisco Morazán' },
+                subregion: { id: '4', name: 'Distrito Central' },
+            }
+        ]
+    };
 
         it('should include the name of the Area', () => {
             const result = areaSerializerV2.serialize(new AreaModel(area));

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@mapbox/tilebelt": "^1.0.1",
     "JSONStream": "^1.3.0",
     "aws-sdk": "^2.1138.0",
+    "axios": "^1.7.9",
     "bunyan": "^1.8.15",
     "config": "^1.21.0",
     "jsonapi-serializer": "2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1991,7 +1991,7 @@ axios@0.26.1:
   dependencies:
     follow-redirects "^1.14.8"
 
-axios@^1.4.0:
+axios@^1.4.0, axios@^1.7.9:
   version "1.7.9"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.9.tgz#d7d071380c132a24accda1b2cfc1535b79ec650a"
   integrity sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==


### PR DESCRIPTION
[GTC-3092](https://gfw.atlassian.net/browse/GTC-3092)

Now that we have all the major mechanisms in place for storing specific GADM versions and returning an Area representation based on a specific GADM version, this PR adds the step of _trying_ to lookup GADM 4.1 IDs for an Area that currently has GADM 3.6 ID information. This will currently only happen for newly created or updated administrative boundary areas. Like our previous pattern for 3.6, this allows us to ensure that new or updated Areas have 4.1 information going forward. It also logs when a 4.1 lookup isn't successful because there were multiple matches for a 3.6 ID or none. Only a single unambiguous match is considered successful.

# Theory of Operation
Currently, once an administrative boundary Area is ready to be saved or updated, an `adminVersions` collection is created or modified based on its `ISO` or `admin` information. This PR adds an HTTP request with the country/region/subregion names as query parameters to be sent to Data API's `/political/id-lookup` endpoint. Depending on the matches in the response, either a 4.1 AdministrativeVersion is added to the collection or the failed match is logged with details.

**The invariant is that the Area will still be saved/updated**. A failed GADM 4.1 match will **not** cause the operation to fail.

Logging the failed matches will provide invaluable information regarding the effectiveness of matching 4.1 IDs based on 3.6 names.

# Implementation Details
An informal, combined [port/adapter design](https://8thlight.com/insights/a-color-coded-guide-to-ports-and-adapters) abstracts away the Data API call and provides isolation from the core Area microservice code. This creates a clear line between what data the app needs and how it gets it. It also allows for robust unit—and component-level testing.

The affected e2e tests were updated since `nock` detected that network calls were being attempted that it was not configured to mock. Those changes, along with the unit tests, ensure quick testing results with no expensive or abusive network calls to the Data API.

# Testing
Unit tests: $> `clear; NODE_PATH=./app/src npx mocha --timeout 10000 app/test/unit/**/*.test.js`

Unit tests and e2e: $> `./area.sh test`

---

# Behavior Added and Tested
## Admin Lookup Adapter
```
 Admin Lookup Adapter
    Axios Integration
      Creating the Request
        ✔ uses the Data API's Political ID Lookup endpoint
        ✔ sets the `admin_version` query parameter to '4.1'
        Only Country is Provided
          ✔ adds the `country` query parameter with the name of the country
          ✔ does NOT include the `region` query parameter
          ✔ does NOT include the `subregion` query parameter
        Only Country and Region are Provided
          ✔ adds the `country` query parameter with the name of the country
          ✔ adds the `region` query parameter with the name of the region
          ✔ does NOT include the `subregion` query parameter 
        Country, Region, and Subregion are Provided
          ✔ adds the `country` query parameter with the name of the country
          ✔ adds the `region` query parameter with the name of the region
          ✔ adds the `subregion` query parameter with the name of the region
      Transforming the Response
        Only One Match is Made
          ✔ returns an array with the one encoded match
        More Than One Match is Made
          ✔ returns an array with all the encoded matches
        No Match is Made
          ✔ returns an empty array
      Errors
        Axios Throws an Exception
          ✔ logs the error message
          ✔ returns an empty array

```

## Tests Added to Area Entity V2
```
Using Admin Versions to Populate Area Admin Information
        Complete Administrative Boundary Info
          ✔ sets the iso attribute's country, region, and subregion
          ✔ sets the admin attribute's adm0, adm1, and adm2
          ✔ sets the geostore
          ✔ sets the name as a comma separated subregion, region, country
        Country Level Administrative Boundary Info
          ✔ sets the iso attribute's country
          ✔ sets the admin attribute's adm0
          ✔ sets the name to only be the country
        Region Level Administrative Boundary Info
          ✔ sets the iso attribute's country and region
          ✔ sets the admin attribute's adm0 and adm1
          ✔ sets the name to be a comma separated region and country
        Complete IDs for an Administrative Boundary But Names are Missing
          ✔ sets the iso attribute's country, region, and subregion
          ✔ sets the admin attribute's adm0, adm1, and adm2
          ✔ sets the name to an empty string
        Region and Subregion Have Names But Country Name is Missing
          ✔ sets the iso attribute's country, region, and subregion
          ✔ sets the admin attribute's adm0, adm1, and adm2
          ✔ sets the name to a comma separated subregion, region, and empty string for country
        Geostore is not present in the Administrative Boundary
          ✔ removes the geostore attribute
        Region Level Administrative Boundary Info But Region Name is Missing
          ✔ sets the iso attribute's country and region
          ✔ sets the admin attribute's adm0 and adm1
          ✔ sets the name to be the country name
        Entity Does Not Have the Admin Version Requested
          ✔ keeps the original iso attribute's country, region, and subregion
          ✔ keeps the original admin attribute's adm0, adm1, and adm2
          ✔ keeps the original geostore
          ✔ keeps the original name

```