### PR TITLE
GTC-3085: `AdminIdLookupService` reports the 4.1 matches made for a 3.6 name

### DIFF
--- a/app/src/adapters/dataApiAdminLookup.adapter.js
+++ b/app/src/adapters/dataApiAdminLookup.adapter.js
@@ -8,9 +8,11 @@ class DataApiAdminLookup {
         try {
             const params = this.buildQueryParams(administrativeVersion);
             const response = await this.performLookup(params);
-            return this.buildMatchedAdministrativeVersions(response);
+            const matches = this.buildMatchedAdministrativeVersions(response);
+            logger.info(`[AREAS-V2-DataApiAdminLookup-Adapter] GADM 3.6: ${JSON.stringify(administrativeVersion)} -> GADM 4.1 Lookup: ${JSON.stringify(matches)}`);
+            return matches;
         } catch (e) {
-            logger.error(`[AREAS-V2-DataApiAdminLookup-Adapter] Failed to encode AdministrativeVersion: ${JSON.stringify(administrativeVersion)} \n response from DataApi Service was: ${JSON.stringify(e)}`, e);
+            logger.error(`[AREAS-V2-DataApiAdminLookup-Adapter] Failed to encode AdministrativeVersion: ${administrativeVersion} \n response from DataApi Service was: ${e}`, e);
             return [];
         }
     }


### PR DESCRIPTION
This is a tiny follow on for [GTC-3085](https://gfw.atlassian.net/browse/GTC-3092)

Logging the result of the match operation will be important for making it easier to analyse what administrative areas can't be converted.

Logs now show an `info` entry:
**No Match**
```
GADM 3.6: {"provider":"gadm","version":"3.6","geostore":"9d6a96fb116ef62473c9d4925bc47f88","country":{"id":"PER","name":"Admin 1 Peru"},"region":{"id":"26"}} -> GADM 4.1 Lookup: []
```

**Match**
```
GADM 3.6: {"provider":"gadm","version":"3.6","geostore":"3877d36358956f7242a6a63bab22e9b0","country":{"id":"MEX","name":"Mexico"},"region":{"id":"19","name":"Nuevo León"},"subregion":{"id":"39","name":"Monterrey"}} -> GADM 4.1 Lookup: [{"provider":"gadm","version":"4.1","geostore":"","country":{"id":"MEX","name":"México"},"region":{"id":"19","name":"Nuevo León"},"subregion":{"id":"40","name":"Monterrey"}}]
```

And how to conveniently parse the logs:
```bash
grep -o 'GADM 3.6.*GADM 4.1 Lookup: \[.*\]' app.log | sed 's/\\n.*//' | sed 's/\\"/"/g' | less
```
