### PR TITLE
GTC-3092:  Batch Update Areas with GADM 4.1 Admin IDs

### DIFF
--- a/app/src/adapters/dataApiAdminLookup.adapter.js
+++ b/app/src/adapters/dataApiAdminLookup.adapter.js
@@ -12,7 +12,7 @@ class DataApiAdminLookup {
             logger.info(`[AREAS-V2-DataApiAdminLookup-Adapter] GADM 3.6: ${JSON.stringify(administrativeVersion)} -> GADM 4.1 Lookup: ${JSON.stringify(matches)}`);
             return matches;
         } catch (e) {
-            logger.error(`[AREAS-V2-DataApiAdminLookup-Adapter] Failed to encode AdministrativeVersion: ${administrativeVersion} \n response from DataApi Service was: ${e}`, e);
+            logger.error(`[AREAS-V2-DataApiAdminLookup-Adapter] Failed to encode AdministrativeVersion: ${JSON.stringify(administrativeVersion)} \n response from DataApi Service was: ${e}`, e);
             return [];
         }
     }


### PR DESCRIPTION
This batch update uses the same script [used for the 3.6 batch update](https://github.com/gfw-api/gfw-area/tree/a75c488f264f00f1f2401247f047b46c32539518/app/devUtilities).
This is because the 4.1 lookup happens during a _save_ operation.

Any failed matches from the ID lookup service will be logged, allowing us to analyze what was sent to the Data API ID Lookup service.

After the batch update, I'll create a list of unsuccessful matches and other statistics to share with the team.