### PR TITLE
GTC-3094: Add Specified Version on Save from Client

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 const Koa = require('koa');
 const logger = require('logger');
 const koaLogger = require('koa-logger');
@@ -81,7 +82,9 @@ async function init() {
 
             });
 
-            app.use(koaLogger());
+            if (process.env.NODE_ENV !== 'test') {
+                app.use(koaLogger());
+            }
 
             app.use(RWAPIMicroservice.bootstrap({
                 logger,

--- a/app/src/entities/areaV2.entity.js
+++ b/app/src/entities/areaV2.entity.js
@@ -1,3 +1,4 @@
+const { isEqual } = require('lodash');
 const AdministrativeVersion = require('valueObjects/administrativeVersion');
 const AdminLookupService = require('services/adminLookup.service');
 
@@ -81,23 +82,65 @@ class AreaEntity {
     }
 
     /**
+     * Retrieves source information from the area model.
+     *
+     * This function checks for a valid source object in both the `admin` and `iso` properties of the area model.
+     * Both `admin` and `iso` are considered aliases and may contain a source object, with the `admin` source being
+     * prioritized. If both the provider and version are available in the admin source, that information is returned.
+     * Otherwise, the function falls back to the iso source. If neither source provides valid data, it returns the
+     * default value from AdministrativeVersion.Sources.GADM_3_6.
+     *
+     * @returns {{provider: string, version: string}} An object containing the provider and version of the source,
+     *   or the default source if neither admin nor iso has valid information.
+     */
+    gatherSourceInfo() {
+        const { provider: adminProvider, version: adminVersion } = this.areaModel.admin?.source?.toObject() ?? {};
+        const { provider: isoProvider, version: isoVersion } = this.areaModel.iso?.source?.toObject() ?? {};
+
+        if (adminProvider && adminVersion) {
+            return { provider: adminProvider, version: adminVersion };
+        }
+
+        if (isoProvider && isoVersion) {
+            return { provider: isoProvider, version: isoVersion };
+        }
+
+        return AdministrativeVersion.Sources.GADM_3_6;
+    }
+
+    /**
      * Build and add (or update) an AdministrativeVersion entry in `areaModel.adminVersions`.
-     * Will only proceed if the area is an administrative boundary.
+     *
+     * This method only proceeds if the area is an administrative boundary. It gathers source
+     * information from the area model (prioritizing the `admin` source over the `iso` source),
+     * then builds a new AdministrativeVersion entry using the area's geostore, administrative names,
+     * administrative IDs, and the retrieved source information.
+     *
+     * **Important:** If the source information indicates GADM 4.1, the AdminLookupService is not used.
+     * This is done to prevent potentially overwriting data that a client has explicitly saved.
+     *
+     * @async
+     * @returns {Promise<void>}
      */
     async populateAdminVersions() {
         if (!this.isAdministrativeBoundary()) return;
+
+        const sourceInfo = this.gatherSourceInfo();
 
         const adminVersion = AdministrativeVersion.build(
             this.areaModel.geostore,
             this.gatherAdministrativeNames(),
             this.gatherAdministrativeIds(),
+            sourceInfo,
         );
 
         this.addAdminVersion(adminVersion);
 
-        const gadm41AdminVersionMatches = await AdminLookupService.findMatch(adminVersion);
-        if (gadm41AdminVersionMatches?.length === 1) {
-            this.addAdminVersion(gadm41AdminVersionMatches.pop());
+        if (!isEqual(sourceInfo, AdministrativeVersion.Sources.GADM_4_1)) {
+            const gadm41AdminVersionMatches = await AdminLookupService.findMatch(adminVersion);
+            if (gadm41AdminVersionMatches?.length === 1) {
+                this.addAdminVersion(gadm41AdminVersionMatches.pop());
+            }
         }
     }
 
@@ -128,16 +171,20 @@ class AreaEntity {
      *
      * This function:
      *  1. Checks if the current area represents an administrative boundary; returns early if not.
-     *  2. Searches `areaModel.adminVersions` for an entry matching the provided `adminVersion`.
-     *  3. If found, sets:
-     *     - `areaModel.iso` with `{ country, region, subregion }`.
-     *     - `areaModel.admin` with `{ adm0, adm1, adm2 }`.
+     *  2. If `areaModel.adminVersions` is missing or empty:
+     *     - If `areaModel.iso` has a `country`, sets `areaModel.iso.source` to `{ provider: 'gadm', version: '3.6' }`.
+     *     - If `areaModel.admin` has an `adm0`, sets `areaModel.admin.source` to `{ provider: 'gadm', version: '3.6' }`.
+     *     - Returns early.
+     *  3. Otherwise, searches `areaModel.adminVersions` for an entry matching the provided `adminVersion`.
+     *  4. If found, sets:
+     *     - `areaModel.iso` with `{ country, region, subregion }` and associated source information.
+     *     - `areaModel.admin` with `{ adm0, adm1, adm2 }` and associated source information.
      *     - `areaModel.geostore`.
      *     - `areaModel.name` using subregion, region, and country names.
      *       - Note: In **some** test and production data scenarios where subregion or region is present
      *         but no country, the name intentionally ends with a trailing comma (e.g. `"Subregion, Region,"`).
      *         This behavior is required by existing tests and cannot be omitted without breaking them.
-     *  4. If not found, the function returns without making changes.
+     *  5. If no matching entry is found, the function returns without making further changes.
      *
      * @param {Object} adminVersion - The administrative version object used to find a matching entry
      *                                in `areaModel.adminVersions`.
@@ -149,16 +196,34 @@ class AreaEntity {
             return;
         }
 
+        if (!this.areaModel.adminVersions || this.areaModel.adminVersions.length === 0) { // no adminVersions history!
+            if (this.areaModel.iso?.country) {
+                this.areaModel.iso.source = {
+                    provider: 'gadm',
+                    version: '3.6',
+                };
+            }
+
+            if (this.areaModel.admin?.adm0) {
+                this.areaModel.admin.source = {
+                    provider: 'gadm',
+                    version: '3.6',
+                };
+            }
+
+            return;
+        }
+
         const adminInfo = this.areaModel.adminVersions.find(
             (v) => adminVersion.equals(new AdministrativeVersion(v))
         );
 
-        if (!adminInfo) { // didn't find the requested version
+        if (!adminInfo) { // didn't find the requested version but there are others
             return;
         }
 
         const {
-            country, region, subregion, geostore
+            provider, version, country, region, subregion, geostore
         } = adminInfo;
 
         this.areaModel.geostore = geostore;
@@ -167,12 +232,20 @@ class AreaEntity {
             country: country?.id,
             region: region?.id,
             subregion: subregion?.id,
+            source: {
+                provider,
+                version,
+            },
         };
 
         this.areaModel.admin = {
             adm0: country?.id,
             adm1: region?.id,
             adm2: subregion?.id,
+            source: {
+                provider,
+                version,
+            },
         };
 
         const nameParts = [];

--- a/app/src/models/area.modelV2.js
+++ b/app/src/models/area.modelV2.js
@@ -35,6 +35,11 @@ const AdminVersion = new Schema({
     },
 }, { _id: false });
 
+const Source = new Schema({
+    provider: { type: String, required: true, trim: true },
+    version: { type: String, required: true, trim: true },
+}, { _id: false });
+
 const Area = new Schema({
     name: { type: String, required: false, trim: true },
     application: {
@@ -54,12 +59,20 @@ const Area = new Schema({
         country: { type: String, required: false, trim: true },
         region: { type: String, required: false, trim: true },
         subregion: { type: String, required: false, trim: true },
+        source: {
+            type: Source,
+            required: false,
+        }
     },
     admin: {
         _id: false,
         adm0: { type: String, required: false, trim: true },
         adm1: { type: Number, required: false, trim: true },
-        adm2: { type: Number, required: false, trim: true }
+        adm2: { type: Number, required: false, trim: true },
+        source: {
+            type: Source,
+            required: false,
+        },
     },
     env: {
         type: String, required: true, default: 'production', trim: true

--- a/app/src/routes/api/v2/area.router.js
+++ b/app/src/routes/api/v2/area.router.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 const Router = require('koa-router');
 const logger = require('logger');
 const config = require('config');
@@ -10,6 +11,8 @@ const SubscriptionService = require('services/subscription.service');
 const mongoose = require('mongoose');
 const MailService = require('services/mail.service');
 const gladAlertTypes = require('models/glad-alert-types');
+const AreaEntity = require('entities/areaV2.entity');
+const AdministrativeVersion = require('valueObjects/administrativeVersion');
 const UserService = require('../../../services/user.service');
 
 const shouldUseAllFilter = (ctx) => ctx.state.loggedUser.role === 'ADMIN' && ctx.query.all && ctx.query.all.trim().toLowerCase() === 'true';
@@ -222,23 +225,28 @@ class AreaRouterV2 {
             use.id = ctx.request.body.use ? ctx.request.body.use.id : null;
             use.name = ctx.request.body.use ? ctx.request.body.use.name : null;
         }
+
+        const { iso: isoBody, admin: adminBody } = ctx.request.body;
         const iso = {};
-        if (ctx.request.body.iso) {
-            iso.country = ctx.request.body.iso ? ctx.request.body.iso.country : null;
-            iso.region = ctx.request.body.iso ? ctx.request.body.iso.region : null;
+        const admin = {};
+        if (isoBody) {
+            iso.country = isoBody.country ?? null;
+            iso.region = isoBody.region ?? null;
+            iso.source = isoBody.source ? { ...isoBody.source } : null;
             if (iso.country || iso.region) {
                 isSaved = true;
             }
         }
-        const admin = {};
-        if (ctx.request.body.admin) {
-            admin.adm0 = ctx.request.body.admin ? ctx.request.body.admin.adm0 : null;
-            admin.adm1 = ctx.request.body.admin ? ctx.request.body.admin.adm1 : null;
-            admin.adm2 = ctx.request.body.admin ? ctx.request.body.admin.adm2 : null;
+        if (adminBody) {
+            admin.adm0 = adminBody.adm0 ?? null;
+            admin.adm1 = adminBody.adm1 ?? null;
+            admin.adm2 = adminBody.adm2 ?? null;
+            admin.source = adminBody.source ? { ...adminBody.source } : null;
             if (admin.adm0) {
                 isSaved = true;
             }
         }
+
         let wdpaid = null;
         if (ctx.request.body.wdpaid) {
             wdpaid = ctx.request.body.wdpaid;
@@ -317,7 +325,8 @@ class AreaRouterV2 {
         }
 
         area = await SubscriptionService.mergeSubscriptionSpecificProps(area, ctx.request.headers['x-api-key']);
-        ctx.body = AreaSerializerV2.serialize(area);
+        const administrativeVersion = new AdministrativeVersion(new AreaEntity(area).gatherSourceInfo());
+        ctx.body = AreaSerializerV2.serialize(area, null, administrativeVersion);
 
         if (email) {
             const { application, status, language } = area;
@@ -406,19 +415,30 @@ class AreaRouterV2 {
             use.name = body.use ? body.use.name : null;
         }
         area.use = use;
+
+        const { iso: isoBody, admin: adminBody } = body;
         const iso = {};
-        if (body.iso) {
-            iso.country = body.iso ? body.iso.country : null;
-            iso.region = body.iso ? body.iso.region : null;
+        const admin = {};
+        if (isoBody) {
+            iso.country = isoBody.country ?? null;
+            iso.region = isoBody.region ?? null;
+            iso.source = isoBody.source ? { ...isoBody.source } : null;
+            if (iso.country || iso.region) {
+                isSaved = true;
+            }
         }
         area.iso = iso;
-        const admin = {};
-        if (body.admin) {
-            admin.adm0 = body.admin ? body.admin.adm0 : null;
-            admin.adm1 = body.admin ? body.admin.adm1 : null;
-            admin.adm2 = body.admin ? body.admin.adm2 : null;
+        if (adminBody) {
+            admin.adm0 = adminBody.adm0 ?? null;
+            admin.adm1 = adminBody.adm1 ?? null;
+            admin.adm2 = adminBody.adm2 ?? null;
+            admin.source = adminBody.source ? { ...adminBody.source } : null;
+            if (admin.adm0) {
+                isSaved = true;
+            }
         }
         area.admin = admin;
+
         if (body.datasets) {
             area.datasets = JSON.parse(body.datasets);
         }
@@ -479,7 +499,8 @@ class AreaRouterV2 {
         }
 
         area = await SubscriptionService.mergeSubscriptionSpecificProps(area, ctx.request.headers['x-api-key']);
-        ctx.body = AreaSerializerV2.serialize(area);
+        const administrativeVersion = new AdministrativeVersion(new AreaEntity(area).gatherSourceInfo());
+        ctx.body = AreaSerializerV2.serialize(area, null, administrativeVersion);
 
         if (area.email && area.status === 'saved') {
             const { email, application } = area;

--- a/app/src/serializers/adminSourceUtils.js
+++ b/app/src/serializers/adminSourceUtils.js
@@ -1,5 +1,4 @@
 const GADM_VERSION_2_8 = '2.8';
-const GADM_VERSION_3_6 = '3.6';
 
 let gadmVersion = GADM_VERSION_2_8;
 
@@ -52,9 +51,4 @@ const addV1SourceForAdministrativeAreas = (data) => {
     return addSourceForAdministrativeAreas(data);
 };
 
-const addV2SourceForAdministrativeAreas = (data) => {
-    gadmVersion = GADM_VERSION_3_6;
-    return addSourceForAdministrativeAreas(data);
-};
-
-module.exports = { addV1SourceForAdministrativeAreas, addV2SourceForAdministrativeAreas };
+module.exports = { addV1SourceForAdministrativeAreas };

--- a/app/src/serializers/area.serializerV2.js
+++ b/app/src/serializers/area.serializerV2.js
@@ -3,7 +3,6 @@ const JSONAPISerializer = require('jsonapi-serializer').Serializer;
 const AreaModel = require('models/area.modelV2');
 const AdministrativeVersion = require('valueObjects/administrativeVersion');
 const AreaEntity = require('entities/areaV2.entity');
-const { addV2SourceForAdministrativeAreas } = require('./adminSourceUtils');
 
 const areaSerializer = new JSONAPISerializer('area', {
     attributes: [
@@ -46,14 +45,13 @@ const areaSerializer = new JSONAPISerializer('area', {
 
 class AreaSerializer {
 
-    static serialize(data, link = null) {
+    static serialize(data, link = null, adminVersion = AdministrativeVersion.Versions.GADM_3_6) {
 
         const models = link !== null ? data.docs : [data];
-        const GADM_3_6 = new AdministrativeVersion();
         models.forEach((areaModel) => {
             const original = new AreaModel(areaModel).toObject(); // ensure we have an new object built from a model
             try {
-                new AreaEntity(areaModel).populateAdminInfo(GADM_3_6);
+                new AreaEntity(areaModel).populateAdminInfo(adminVersion);
             } catch (e) {
                 logger.error(`[AREAS-V2-Entity] Could not populate Admin Info for Area ID: '${areaModel.id}'`, e);
                 Object.assign(areaModel, original);
@@ -71,7 +69,7 @@ class AreaSerializer {
             });
         }
 
-        serializedData.data = addV2SourceForAdministrativeAreas(JSON.parse(JSON.stringify(serializedData.data)));
+        serializedData.data = JSON.parse(JSON.stringify(serializedData.data));
 
         if (link) {
             serializedData.links = {

--- a/app/src/valueObjects/administrativeVersion.js
+++ b/app/src/valueObjects/administrativeVersion.js
@@ -6,6 +6,16 @@
  */
 class AdministrativeVersion {
 
+    static Sources = {
+        GADM_3_6: { provider: 'gadm', version: '3.6' },
+        GADM_4_1: { provider: 'gadm', version: '4.1' },
+    };
+
+    static Versions = {
+        GADM_3_6: new AdministrativeVersion(this.Sources.GADM_3_6),
+        GADM_4_1: new AdministrativeVersion(this.Sources.GADM_4_1),
+    };
+
     /**
      * Constructs a new AdministrativeVersion object from given geostore and
      * administrative level data.
@@ -18,7 +28,8 @@ class AdministrativeVersion {
     static build(
         geostore,
         [countryName, regionName, subregionName],
-        [countryId, regionId, subregionId]
+        [countryId, regionId, subregionId],
+        { provider, version } = this.Sources.GADM_3_6
     ) {
         return new AdministrativeVersion({
             geostore,
@@ -34,6 +45,8 @@ class AdministrativeVersion {
                 id: subregionId,
                 name: subregionName,
             },
+            provider,
+            version,
         });
     }
 

--- a/app/test/e2e/v2/create-area.spec.js
+++ b/app/test/e2e/v2/create-area.spec.js
@@ -33,6 +33,173 @@ describe('V2 - Create area', () => {
         sinon.stub(MailService, 'sendMail').returns(new Promise((resolve) => resolve()));
     });
 
+    describe('Explicitly Create A GADM 4.1 Administrative Area', () => {
+        it('considers the `iso` source provider and version in the payload', async () => {
+            mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
+
+            const response = await requester
+                .post(`/api/v2/area`)
+                .set('Authorization', 'Bearer abcd')
+                .set('x-api-key', 'api-key-test')
+                .send({
+                    name: 'Portugal area',
+                    iso: {
+                        country: 'createdCountryIso',
+                        region: 'createdRegionIso',
+                        source: {
+                            provider: 'gadm',
+                            version: '4.1',
+                        }
+                    },
+                });
+
+            response.status.should.equal(200);
+            response.body.should.have.property('data').and.be.an('object');
+            response.body.data.should.have.property('type').and.equal('area');
+            response.body.data.should.have.property('id');
+            response.body.data.attributes.should.have.property('name').and.equal('Portugal area');
+            response.body.data.attributes.should.have.property('userId').and.equal(USERS.USER.id);
+            response.body.data.attributes.should.have.property('iso').and.deep.equal({
+                country: 'createdCountryIso',
+                region: 'createdRegionIso',
+                source: {
+                    provider: 'gadm',
+                    version: '4.1',
+                }
+            });
+            response.body.data.attributes.should.have.property('createdAt');
+            response.body.data.attributes.should.have.property('updatedAt');
+            new Date(response.body.data.attributes.updatedAt).should.closeToTime(new Date(response.body.data.attributes.createdAt), 5);
+        });
+
+        it('considers the `admin` source provider and version in the payload', async () => {
+            mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
+
+            const response = await requester
+                .post(`/api/v2/area`)
+                .set('Authorization', 'Bearer abcd')
+                .set('x-api-key', 'api-key-test')
+                .send({
+                    name: 'Portugal area',
+                    admin: {
+                        adm0: 'createdCountryIso',
+                        source: {
+                            provider: 'gadm',
+                            version: '4.1',
+                        }
+                    },
+                });
+
+            response.status.should.equal(200);
+            response.body.should.have.property('data').and.be.an('object');
+            response.body.data.should.have.property('type').and.equal('area');
+            response.body.data.should.have.property('id');
+            response.body.data.attributes.should.have.property('name').and.equal('Portugal area');
+            response.body.data.attributes.should.have.property('userId').and.equal(USERS.USER.id);
+            response.body.data.attributes.should.have.property('admin').and.deep.equal({
+                adm0: 'createdCountryIso',
+                source: {
+                    provider: 'gadm',
+                    version: '4.1',
+                }
+            });
+            response.body.data.attributes.should.have.property('createdAt');
+            response.body.data.attributes.should.have.property('updatedAt');
+            new Date(response.body.data.attributes.updatedAt).should.closeToTime(new Date(response.body.data.attributes.createdAt), 5);
+        });
+    });
+
+    describe('Explicitly Create A GADM 3.6 Administrative Area', () => {
+        it('considers the source provider and version in the payload', async () => {
+            nock('https://data-api.globalforestwatch.org')
+                .get('/political/id-lookup')
+                .query({
+                    admin_version: '4.1',
+                    country: 'Portugal area',
+                })
+                .reply(200, {
+                    data: {
+                        adminSource: 'GADM',
+                        adminVersion: '4.1',
+                        matches: []
+                    },
+                    status: 'success'
+                });
+
+            mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
+
+            const response = await requester
+                .post(`/api/v2/area`)
+                .set('Authorization', 'Bearer abcd')
+                .set('x-api-key', 'api-key-test')
+                .send({
+                    name: 'Portugal area',
+                    iso: {
+                        country: 'createdCountryIso',
+                        region: 'createdRegionIso',
+                        source: {
+                            provider: 'gadm',
+                            version: '3.6',
+                        }
+                    },
+                });
+
+            response.status.should.equal(200);
+            response.body.should.have.property('data').and.be.an('object');
+            response.body.data.should.have.property('type').and.equal('area');
+            response.body.data.should.have.property('id');
+            response.body.data.attributes.should.have.property('name').and.equal('Portugal area');
+            response.body.data.attributes.should.have.property('userId').and.equal(USERS.USER.id);
+            response.body.data.attributes.should.have.property('iso').and.deep.equal({
+                country: 'createdCountryIso',
+                region: 'createdRegionIso',
+                source: {
+                    provider: 'gadm',
+                    version: '3.6',
+                }
+            });
+            response.body.data.attributes.should.have.property('createdAt');
+            response.body.data.attributes.should.have.property('updatedAt');
+            new Date(response.body.data.attributes.updatedAt).should.closeToTime(new Date(response.body.data.attributes.createdAt), 5);
+        });
+
+        it('considers the `admin` source provider and version in the payload', async () => {
+            mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
+
+            const response = await requester
+                .post(`/api/v2/area`)
+                .set('Authorization', 'Bearer abcd')
+                .set('x-api-key', 'api-key-test')
+                .send({
+                    name: 'Portugal area',
+                    admin: {
+                        adm0: 'createdCountryIso',
+                        source: {
+                            provider: 'gadm',
+                            version: '3.6',
+                        }
+                    },
+                });
+
+            response.status.should.equal(200);
+            response.body.should.have.property('data').and.be.an('object');
+            response.body.data.should.have.property('type').and.equal('area');
+            response.body.data.should.have.property('id');
+            response.body.data.attributes.should.have.property('name').and.equal('Portugal area');
+            response.body.data.attributes.should.have.property('userId').and.equal(USERS.USER.id);
+            response.body.data.attributes.should.have.property('admin').and.deep.equal({
+                adm0: 'createdCountryIso',
+                source: {
+                    provider: 'gadm',
+                    version: '3.6',
+                }
+            });
+            response.body.data.attributes.should.have.property('createdAt');
+            response.body.data.attributes.should.have.property('updatedAt');
+            new Date(response.body.data.attributes.updatedAt).should.closeToTime(new Date(response.body.data.attributes.createdAt), 5);
+        });
+    });
+
     it('Creating an area without being logged in should return a 401 - "Not logged" error', async () => {
         mockValidateRequestWithApiKey({});
 

--- a/app/test/e2e/v2/update-area.spec.js
+++ b/app/test/e2e/v2/update-area.spec.js
@@ -134,6 +134,296 @@ describe('V2 - Update area', () => {
         });
     });
 
+    describe('Explicitly Update A GADM 4.1 Administrative Area', () => {
+        it('updates an `iso` area while being logged in as a user that owns the area should return a 200 HTTP code and the updated area object', async () => {
+            mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
+
+            const testArea = await new Area(createArea({ userId: USERS.USER.id })).save();
+
+            const response = await requester
+                .patch(`/api/v2/area/${testArea.id}`)
+                .set('Authorization', 'Bearer abcd')
+                .set('x-api-key', 'api-key-test')
+                .send({
+                    name: 'Portugal area',
+                    application: 'rw',
+                    geostore: '713899292fc118a915741728ef84a2a7',
+                    wdpaid: 3,
+                    use: { id: 'bbb', name: 'updated name' },
+                    iso: {
+                        country: 'updatedCountryIso',
+                        region: 'updatedRegionIso',
+                        source: {
+                            provider: 'gadm',
+                            version: '4.1',
+                        }
+                    },
+                    datasets: '[{"slug":"viirs","name":"VIIRS","startDate":"7","endDate":"1","lastUpdate":1513793462776.0,"_id":"5a3aa9eb98b5910011731f66","active":true,"cache":true}]',
+                    templateId: 'updatedTemplateId'
+                });
+
+            response.status.should.equal(200);
+
+            response.body.should.have.property('data').and.be.an('object');
+            response.body.data.should.have.property('type').and.equal('area');
+            response.body.data.should.have.property('id').and.equal(testArea.id);
+            response.body.data.attributes.should.have.property('name').and.equal('Portugal area');
+            response.body.data.attributes.should.have.property('application').and.equal('rw');
+            response.body.data.attributes.should.have.property('geostore').and.equal('713899292fc118a915741728ef84a2a7');
+            response.body.data.attributes.should.have.property('userId').and.equal(testArea.userId);
+            response.body.data.attributes.should.have.property('wdpaid').and.equal(3);
+            response.body.data.attributes.should.have.property('use').and.deep.equal({
+                id: 'bbb',
+                name: 'updated name'
+            });
+            response.body.data.attributes.should.have.property('iso').and.deep.equal({
+                country: 'updatedCountryIso',
+                region: 'updatedRegionIso',
+                source: {
+                    provider: 'gadm',
+                    version: '4.1',
+                }
+            });
+            response.body.data.attributes.should.have.property('createdAt');
+            response.body.data.attributes.should.have.property('updatedAt');
+            new Date(response.body.data.attributes.updatedAt).should.afterTime(new Date(response.body.data.attributes.createdAt));
+            response.body.data.attributes.should.have.property('datasets').and.be.an('array').and.length(1);
+            response.body.data.attributes.datasets[0].should.deep.equal({
+                cache: true,
+                active: true,
+                _id: '5a3aa9eb98b5910011731f66',
+                slug: 'viirs',
+                name: 'VIIRS',
+                startDate: '7',
+                endDate: '1',
+                lastUpdate: 1513793462776
+            });
+        });
+
+        it('updates an `admin` area while being logged in as a user that owns the area should return a 200 HTTP code and the updated area object', async () => {
+            mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
+
+            const testArea = await new Area(createArea({ userId: USERS.USER.id })).save();
+
+            const response = await requester
+                .patch(`/api/v2/area/${testArea.id}`)
+                .set('Authorization', 'Bearer abcd')
+                .set('x-api-key', 'api-key-test')
+                .send({
+                    name: 'Portugal area',
+                    application: 'rw',
+                    geostore: '713899292fc118a915741728ef84a2a7',
+                    wdpaid: 3,
+                    use: { id: 'bbb', name: 'updated name' },
+                    admin: {
+                        adm0: 'updatedCountryIso',
+                        source: {
+                            provider: 'gadm',
+                            version: '4.1',
+                        }
+                    },
+                    datasets: '[{"slug":"viirs","name":"VIIRS","startDate":"7","endDate":"1","lastUpdate":1513793462776.0,"_id":"5a3aa9eb98b5910011731f66","active":true,"cache":true}]',
+                    templateId: 'updatedTemplateId'
+                });
+
+            response.status.should.equal(200);
+
+            response.body.should.have.property('data').and.be.an('object');
+            response.body.data.should.have.property('type').and.equal('area');
+            response.body.data.should.have.property('id').and.equal(testArea.id);
+            response.body.data.attributes.should.have.property('name').and.equal('Portugal area');
+            response.body.data.attributes.should.have.property('application').and.equal('rw');
+            response.body.data.attributes.should.have.property('geostore').and.equal('713899292fc118a915741728ef84a2a7');
+            response.body.data.attributes.should.have.property('userId').and.equal(testArea.userId);
+            response.body.data.attributes.should.have.property('wdpaid').and.equal(3);
+            response.body.data.attributes.should.have.property('use').and.deep.equal({
+                id: 'bbb',
+                name: 'updated name'
+            });
+            response.body.data.attributes.should.have.property('admin').and.deep.equal({
+                adm0: 'updatedCountryIso',
+                source: {
+                    provider: 'gadm',
+                    version: '4.1',
+                }
+            });
+            response.body.data.attributes.should.have.property('createdAt');
+            response.body.data.attributes.should.have.property('updatedAt');
+            new Date(response.body.data.attributes.updatedAt).should.afterTime(new Date(response.body.data.attributes.createdAt));
+            response.body.data.attributes.should.have.property('datasets').and.be.an('array').and.length(1);
+            response.body.data.attributes.datasets[0].should.deep.equal({
+                cache: true,
+                active: true,
+                _id: '5a3aa9eb98b5910011731f66',
+                slug: 'viirs',
+                name: 'VIIRS',
+                startDate: '7',
+                endDate: '1',
+                lastUpdate: 1513793462776
+            });
+        });
+    });
+
+    describe('Explicitly Update A GADM 3.6 Administrative Area', () => {
+        it('updates an `iso` area while being logged in as a user that owns the area should return a 200 HTTP code and the updated area object', async () => {
+            mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
+
+            nock('https://data-api.globalforestwatch.org')
+                .get('/political/id-lookup')
+                .query({
+                    admin_version: '4.1',
+                    country: 'Portugal area',
+                })
+                .reply(200, {
+                    data: {
+                        adminSource: 'GADM',
+                        adminVersion: '4.1',
+                        matches: []
+                    },
+                    status: 'success'
+                });
+
+            const testArea = await new Area(createArea({ userId: USERS.USER.id })).save();
+
+            const response = await requester
+                .patch(`/api/v2/area/${testArea.id}`)
+                .set('Authorization', 'Bearer abcd')
+                .set('x-api-key', 'api-key-test')
+                .send({
+                    name: 'Portugal area',
+                    application: 'rw',
+                    geostore: '713899292fc118a915741728ef84a2a7',
+                    wdpaid: 3,
+                    use: { id: 'bbb', name: 'updated name' },
+                    iso: {
+                        country: 'updatedCountryIso',
+                        region: 'updatedRegionIso',
+                        source: {
+                            provider: 'gadm',
+                            version: '3.6',
+                        }
+                    },
+                    datasets: '[{"slug":"viirs","name":"VIIRS","startDate":"7","endDate":"1","lastUpdate":1513793462776.0,"_id":"5a3aa9eb98b5910011731f66","active":true,"cache":true}]',
+                    templateId: 'updatedTemplateId'
+                });
+
+            response.status.should.equal(200);
+
+            response.body.should.have.property('data').and.be.an('object');
+            response.body.data.should.have.property('type').and.equal('area');
+            response.body.data.should.have.property('id').and.equal(testArea.id);
+            response.body.data.attributes.should.have.property('name').and.equal('Portugal area');
+            response.body.data.attributes.should.have.property('application').and.equal('rw');
+            response.body.data.attributes.should.have.property('geostore').and.equal('713899292fc118a915741728ef84a2a7');
+            response.body.data.attributes.should.have.property('userId').and.equal(testArea.userId);
+            response.body.data.attributes.should.have.property('wdpaid').and.equal(3);
+            response.body.data.attributes.should.have.property('use').and.deep.equal({
+                id: 'bbb',
+                name: 'updated name'
+            });
+            response.body.data.attributes.should.have.property('iso').and.deep.equal({
+                country: 'updatedCountryIso',
+                region: 'updatedRegionIso',
+                source: {
+                    provider: 'gadm',
+                    version: '3.6',
+                }
+            });
+            response.body.data.attributes.should.have.property('createdAt');
+            response.body.data.attributes.should.have.property('updatedAt');
+            new Date(response.body.data.attributes.updatedAt).should.afterTime(new Date(response.body.data.attributes.createdAt));
+            response.body.data.attributes.should.have.property('datasets').and.be.an('array').and.length(1);
+            response.body.data.attributes.datasets[0].should.deep.equal({
+                cache: true,
+                active: true,
+                _id: '5a3aa9eb98b5910011731f66',
+                slug: 'viirs',
+                name: 'VIIRS',
+                startDate: '7',
+                endDate: '1',
+                lastUpdate: 1513793462776
+            });
+        });
+
+        it('updates an `admin` area while being logged in as a user that owns the area should return a 200 HTTP code and the updated area object', async () => {
+            mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
+
+            nock('https://data-api.globalforestwatch.org')
+                .get('/political/id-lookup')
+                .query({
+                    admin_version: '4.1',
+                    country: 'Portugal area',
+                })
+                .reply(200, {
+                    data: {
+                        adminSource: 'GADM',
+                        adminVersion: '4.1',
+                        matches: []
+                    },
+                    status: 'success'
+                });
+
+            const testArea = await new Area(createArea({ userId: USERS.USER.id })).save();
+
+            const response = await requester
+                .patch(`/api/v2/area/${testArea.id}`)
+                .set('Authorization', 'Bearer abcd')
+                .set('x-api-key', 'api-key-test')
+                .send({
+                    name: 'Portugal area',
+                    application: 'rw',
+                    geostore: '713899292fc118a915741728ef84a2a7',
+                    wdpaid: 3,
+                    use: { id: 'bbb', name: 'updated name' },
+                    admin: {
+                        adm0: 'updatedCountryIso',
+                        source: {
+                            provider: 'gadm',
+                            version: '3.6',
+                        }
+                    },
+                    datasets: '[{"slug":"viirs","name":"VIIRS","startDate":"7","endDate":"1","lastUpdate":1513793462776.0,"_id":"5a3aa9eb98b5910011731f66","active":true,"cache":true}]',
+                    templateId: 'updatedTemplateId'
+                });
+
+            response.status.should.equal(200);
+
+            response.body.should.have.property('data').and.be.an('object');
+            response.body.data.should.have.property('type').and.equal('area');
+            response.body.data.should.have.property('id').and.equal(testArea.id);
+            response.body.data.attributes.should.have.property('name').and.equal('Portugal area');
+            response.body.data.attributes.should.have.property('application').and.equal('rw');
+            response.body.data.attributes.should.have.property('geostore').and.equal('713899292fc118a915741728ef84a2a7');
+            response.body.data.attributes.should.have.property('userId').and.equal(testArea.userId);
+            response.body.data.attributes.should.have.property('wdpaid').and.equal(3);
+            response.body.data.attributes.should.have.property('use').and.deep.equal({
+                id: 'bbb',
+                name: 'updated name'
+            });
+            response.body.data.attributes.should.have.property('admin').and.deep.equal({
+                adm0: 'updatedCountryIso',
+                source: {
+                    provider: 'gadm',
+                    version: '3.6',
+                }
+            });
+            response.body.data.attributes.should.have.property('createdAt');
+            response.body.data.attributes.should.have.property('updatedAt');
+            new Date(response.body.data.attributes.updatedAt).should.afterTime(new Date(response.body.data.attributes.createdAt));
+            response.body.data.attributes.should.have.property('datasets').and.be.an('array').and.length(1);
+            response.body.data.attributes.datasets[0].should.deep.equal({
+                cache: true,
+                active: true,
+                _id: '5a3aa9eb98b5910011731f66',
+                slug: 'viirs',
+                name: 'VIIRS',
+                startDate: '7',
+                endDate: '1',
+                lastUpdate: 1513793462776
+            });
+        });
+    });
+
     it('Updating an area with a file while being logged in as a user that owns the area should upload the image to S3 and return a 200 HTTP code and the updated area object', async () => {
         mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
 

--- a/app/test/unit/entities/areaV2.entity.test.js
+++ b/app/test/unit/entities/areaV2.entity.test.js
@@ -43,7 +43,7 @@ describe('Area Entity V2', () => {
                 const areaModel = new AreaModel(areaData);
                 const areaEntity = new AreaEntity(areaModel);
 
-                await areaEntity.populateAdminVersions(AdminLookupService);
+                await areaEntity.populateAdminVersions();
 
                 expect(areaModel.toObject().adminVersions[1]).to.deep.include({
                     provider: 'gadm',
@@ -718,6 +718,10 @@ describe('Area Entity V2', () => {
                         country: 'KEN',
                         region: '15',
                         subregion: '1',
+                        source: {
+                            provider: 'gadm',
+                            version: '3.6',
+                        },
                     });
                 });
 
@@ -726,6 +730,10 @@ describe('Area Entity V2', () => {
                         adm0: 'KEN',
                         adm1: 15,
                         adm2: 1,
+                        source: {
+                            provider: 'gadm',
+                            version: '3.6',
+                        },
                     });
                 });
 
@@ -770,13 +778,13 @@ describe('Area Entity V2', () => {
                 });
 
                 it('sets the iso attribute\'s country', () => {
-                    expect(JSON.parse(JSON.stringify(areaModel)).iso).to.deep.equal({
+                    expect(JSON.parse(JSON.stringify(areaModel)).iso).to.deep.include({
                         country: 'KEN',
                     });
                 });
 
                 it('sets the admin attribute\'s adm0', () => {
-                    expect(JSON.parse(JSON.stringify(areaModel)).admin).to.deep.equal({
+                    expect(JSON.parse(JSON.stringify(areaModel)).admin).to.deep.include({
                         adm0: 'KEN',
                     });
                 });
@@ -819,14 +827,14 @@ describe('Area Entity V2', () => {
                 });
 
                 it('sets the iso attribute\'s country and region', () => {
-                    expect(JSON.parse(JSON.stringify(areaModel)).iso).to.deep.equal({
+                    expect(JSON.parse(JSON.stringify(areaModel)).iso).to.deep.include({
                         country: 'KEN',
                         region: '15',
                     });
                 });
 
                 it('sets the admin attribute\'s adm0 and adm1', () => {
-                    expect(JSON.parse(JSON.stringify(areaModel)).admin).to.deep.equal({
+                    expect(JSON.parse(JSON.stringify(areaModel)).admin).to.deep.include({
                         adm0: 'KEN',
                         adm1: 15,
                     });
@@ -871,7 +879,7 @@ describe('Area Entity V2', () => {
                 });
 
                 it('sets the iso attribute\'s country, region, and subregion', () => {
-                    expect(JSON.parse(JSON.stringify(areaModel)).iso).to.deep.equal({
+                    expect(JSON.parse(JSON.stringify(areaModel)).iso).to.deep.include({
                         country: 'KEN',
                         region: '15',
                         subregion: '1',
@@ -879,7 +887,7 @@ describe('Area Entity V2', () => {
                 });
 
                 it('sets the admin attribute\'s adm0, adm1, and adm2', () => {
-                    expect(JSON.parse(JSON.stringify(areaModel)).admin).to.deep.equal({
+                    expect(JSON.parse(JSON.stringify(areaModel)).admin).to.deep.include({
                         adm0: 'KEN',
                         adm1: 15,
                         adm2: 1,
@@ -925,7 +933,7 @@ describe('Area Entity V2', () => {
                 });
 
                 it('sets the iso attribute\'s country, region, and subregion', () => {
-                    expect(JSON.parse(JSON.stringify(areaModel)).iso).to.deep.equal({
+                    expect(JSON.parse(JSON.stringify(areaModel)).iso).to.deep.include({
                         country: 'KEN',
                         region: '15',
                         subregion: '1',
@@ -933,7 +941,7 @@ describe('Area Entity V2', () => {
                 });
 
                 it('sets the admin attribute\'s adm0, adm1, and adm2', () => {
-                    expect(JSON.parse(JSON.stringify(areaModel)).admin).to.deep.equal({
+                    expect(JSON.parse(JSON.stringify(areaModel)).admin).to.deep.include({
                         adm0: 'KEN',
                         adm1: 15,
                         adm2: 1,
@@ -1010,14 +1018,14 @@ describe('Area Entity V2', () => {
                 });
 
                 it('sets the iso attribute\'s country and region', () => {
-                    expect(JSON.parse(JSON.stringify(areaModel)).iso).to.deep.equal({
+                    expect(JSON.parse(JSON.stringify(areaModel)).iso).to.deep.include({
                         country: 'KEN',
                         region: '15',
                     });
                 });
 
                 it('sets the admin attribute\'s adm0 and adm1', () => {
-                    expect(JSON.parse(JSON.stringify(areaModel)).admin).to.deep.equal({
+                    expect(JSON.parse(JSON.stringify(areaModel)).admin).to.deep.include({
                         adm0: 'KEN',
                         adm1: 15,
                     });
@@ -1027,7 +1035,7 @@ describe('Area Entity V2', () => {
                     expect(JSON.parse(JSON.stringify(areaModel)).name).to.equal('Kenya');
                 });
             });
-            context('Entity Does Not Have the Admin Version Requested', () => {
+            context('Entity Does Not Have Any Version Information', () => {
                 const areaData = {
                     name: 'Distrito Central, Francisco Morazán, Honduras',
                     geostore: 'abcf7041e2fbc5e8e7774178157ababe',
@@ -1041,7 +1049,7 @@ describe('Area Entity V2', () => {
                         adm1: 8,
                         adm2: 4,
                     },
-                    adminVersions: [] // no versions to match!
+                    adminVersions: [] // no versions!
                 };
 
                 let areaModel;
@@ -1054,18 +1062,36 @@ describe('Area Entity V2', () => {
                 });
 
                 it('keeps the original iso attribute\'s country, region, and subregion', () => {
-                    expect(JSON.parse(JSON.stringify(areaModel)).iso).to.deep.equal({
+                    expect(JSON.parse(JSON.stringify(areaModel)).iso).to.deep.include({
                         country: 'HND',
                         region: '8',
                         subregion: '4',
                     });
                 });
 
+                it('assigns GADM 3.6 as the `iso` source', () => {
+                    expect(areaModel.toObject().iso).to.deep.include({
+                        source: {
+                            provider: 'gadm',
+                            version: '3.6',
+                        },
+                    });
+                });
+
                 it('keeps the original admin attribute\'s adm0, adm1, and adm2', () => {
-                    expect(JSON.parse(JSON.stringify(areaModel)).admin).to.deep.equal({
+                    expect(JSON.parse(JSON.stringify(areaModel)).admin).to.deep.include({
                         adm0: 'HND',
                         adm1: 8,
                         adm2: 4,
+                    });
+                });
+
+                it('assigns GADM 3.6 as the `admin` source', () => {
+                    expect(areaModel.toObject().admin).to.deep.include({
+                        source: {
+                            provider: 'gadm',
+                            version: '3.6',
+                        },
                     });
                 });
 
@@ -1076,6 +1102,126 @@ describe('Area Entity V2', () => {
                 it('keeps the original name', () => {
                     expect(JSON.parse(JSON.stringify(areaModel)).name).to.equal('Distrito Central, Francisco Morazán, Honduras');
                 });
+            });
+        });
+    });
+
+    describe('Specifying GADM 4.1 Before Adding the AdministrativeVersion', () => {
+        let sandbox;
+        let adminLookupServiceMock;
+
+        beforeEach(() => {
+            sandbox = sinon.createSandbox();
+            adminLookupServiceMock = sandbox.stub(AdminLookupService, 'findMatch');
+        });
+
+        afterEach(() => {
+            sandbox.restore();
+        });
+
+        context('Only `admin` Is Populated', () => {
+            it('adds the 4.1 AdministrativeVersion to the collection of adminVersions', async () => {
+                const areaData = {
+                    name: 'Distrito Central, Francisco Morazán, Honduras',
+                    geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+                    admin: {
+                        adm0: 'HND',
+                        adm1: 8,
+                        adm2: 4,
+                        source: {
+                            provider: 'gadm',
+                            version: '4.1',
+                        }
+                    }
+                };
+                const areaModel = new AreaModel(areaData);
+                const areaEntity = new AreaEntity(areaModel);
+
+                await areaEntity.populateAdminVersions();
+
+                expect(areaModel.toObject().adminVersions.length).to.equal(1, 'adminVersions should only have one entry');
+                expect(areaModel.toObject().adminVersions[0]).to.deep.include({
+                    provider: 'gadm',
+                    version: '4.1',
+                    country: { id: 'HND', name: 'Honduras' },
+                    region: { id: '8', name: 'Francisco Morazán' },
+                    subregion: { id: '4', name: 'Distrito Central' }
+                });
+            });
+
+            it('does NOT use the AdminLookupService', async () => {
+                const areaData = {
+                    name: 'Distrito Central, Francisco Morazán, Honduras',
+                    geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+                    admin: {
+                        adm0: 'HND',
+                        adm1: 8,
+                        adm2: 4,
+                        source: {
+                            provider: 'gadm',
+                            version: '4.1',
+                        }
+                    }
+                };
+                const areaModel = new AreaModel(areaData);
+                const areaEntity = new AreaEntity(areaModel);
+
+                await areaEntity.populateAdminVersions();
+
+                sinon.assert.notCalled(adminLookupServiceMock);
+            });
+        });
+
+        context('Only `iso` Is Populated', () => {
+            it('adds the 4.1 AdministrativeVersion to the collection of adminVersions', async () => {
+                const areaData = {
+                    name: 'Distrito Central, Francisco Morazán, Honduras',
+                    geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+                    iso: {
+                        country: 'HND',
+                        region: '8',
+                        subregion: '4',
+                        source: {
+                            provider: 'gadm',
+                            version: '4.1',
+                        }
+                    }
+                };
+                const areaModel = new AreaModel(areaData);
+                const areaEntity = new AreaEntity(areaModel);
+
+                await areaEntity.populateAdminVersions();
+
+                expect(areaModel.toObject().adminVersions.length).to.equal(1, 'adminVersions should only have one entry');
+                expect(areaModel.toObject().adminVersions[0]).to.deep.include({
+                    provider: 'gadm',
+                    version: '4.1',
+                    country: { id: 'HND', name: 'Honduras' },
+                    region: { id: '8', name: 'Francisco Morazán' },
+                    subregion: { id: '4', name: 'Distrito Central' }
+                });
+            });
+
+            it('does NOT use the AdminLookupService', async () => {
+                const areaData = {
+                    name: 'Distrito Central, Francisco Morazán, Honduras',
+                    geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+                    iso: {
+                        country: 'HND',
+                        region: '8',
+                        subregion: '4',
+                        source: {
+                            provider: 'gadm',
+                            version: '4.1',
+                        }
+                    }
+                };
+                const areaModel = new AreaModel(areaData);
+                const areaEntity = new AreaEntity(areaModel);
+
+                await areaEntity.populateAdminVersions();
+
+                sinon.assert.notCalled(adminLookupServiceMock);
             });
         });
     });

--- a/app/test/unit/serializers/adminSourceUtils.test.js
+++ b/app/test/unit/serializers/adminSourceUtils.test.js
@@ -1,5 +1,5 @@
 const chai = require('chai');
-const { addV1SourceForAdministrativeAreas, addV2SourceForAdministrativeAreas } = require('serializers/adminSourceUtils');
+const { addV1SourceForAdministrativeAreas } = require('serializers/adminSourceUtils');
 
 const { expect } = chai;
 
@@ -31,64 +31,6 @@ describe('adminSourceUtils', () => {
             it('should not add source information to the iso attribute', () => {
                 const result = addV1SourceForAdministrativeAreas(serializedCustomAreaFragment);
                 expect(result.attributes.iso).to.not.have.property('source');
-            });
-        });
-    });
-
-    describe('Adding GADM 3.6 Source Information', () => {
-        const serializedAreaFragment = {
-            attributes: {
-                iso: {
-                    country: 'HND',
-                    region: '8',
-                    subregion: '4',
-                },
-            },
-        };
-
-        it('should add GADM 3.6 source information', () => {
-            const result = addV2SourceForAdministrativeAreas(serializedAreaFragment);
-            expect(result.attributes.iso).to.deep.include({ source: { provider: 'gadm', version: '3.6' } });
-        });
-
-        describe('An Administrative Boundary Area with Both an "iso" and "admin" Property', () => {
-            it('should NOT add source information to an empty "iso" object', () => {
-                const serializedAreaFragmentWithEmptyIsoAndAdmin = {
-                    attributes: {
-                        iso: {},
-                        admin: {
-                            adm0: 'HND',
-                            adm1: 8,
-                            adm2: 4
-                        },
-                    },
-                };
-
-                const result = addV2SourceForAdministrativeAreas(serializedAreaFragmentWithEmptyIsoAndAdmin);
-                expect(result.attributes.iso).to.eql({});
-            });
-        });
-
-        describe('An Area That Is NOT An Administrative Boundary', () => {
-            const serializedCustomAreaFragment = {
-                attributes: {
-                    name: 'Distrito Central, Francisco Morazán, Honduras',
-                    geostore: 'abcf7041e2fbc5e8e7774178157ababe',
-                    iso: {},
-                    admin: {
-                        adm0: null,
-                    }
-                }
-            };
-
-            it('should not add source information to the iso attribute', () => {
-                const result = addV1SourceForAdministrativeAreas(serializedCustomAreaFragment);
-                expect(result.attributes.iso).to.not.have.property('source');
-            });
-
-            it('should not add source information to the admin attribute', () => {
-                const result = addV1SourceForAdministrativeAreas(serializedCustomAreaFragment);
-                expect(result.attributes.admin).to.not.have.property('source');
             });
         });
     });

--- a/app/test/unit/serializers/area.serializerV2.test.js
+++ b/app/test/unit/serializers/area.serializerV2.test.js
@@ -22,17 +22,17 @@ describe('Area Serializer V2', () => {
                 adm1: 8,
                 adm2: 4,
             },
-        adminVersions: [
-            {
-                provider: 'gadm',
-                version: '3.6',
-                geostore: 'abcf7041e2fbc5e8e7774178157ababe',
-                country: { id: 'HND', name: 'Honduras' },
-                region: { id: '8', name: 'Francisco Morazán' },
-                subregion: { id: '4', name: 'Distrito Central' },
-            }
-        ]
-    };
+            adminVersions: [
+                {
+                    provider: 'gadm',
+                    version: '3.6',
+                    geostore: 'abcf7041e2fbc5e8e7774178157ababe',
+                    country: { id: 'HND', name: 'Honduras' },
+                    region: { id: '8', name: 'Francisco Morazán' },
+                    subregion: { id: '4', name: 'Distrito Central' },
+                }
+            ]
+        };
 
         it('should include the name of the Area', () => {
             const result = areaSerializerV2.serialize(new AreaModel(area));
@@ -242,11 +242,10 @@ describe('Area Serializer V2', () => {
             sandbox.restore();
         });
 
-        it('returns the Area admin attributes to their original values', () => {
+        it('returns the Area admin attributes to their original values', async () => {
             sandbox.stub(logger, 'error');
             sandbox.stub(AreaEntity.prototype, 'populateAdminInfo').throws(new Error('Test Error'));
             const result = areaSerializerV2.serialize(new AreaModel(area));
-
             expect(result.data.attributes).to.deep.include({
                 name: 'Distrito Central, Francisco Morazán, Honduras',
                 geostore: 'abcf7041e2fbc5e8e7774178157ababe',
@@ -254,13 +253,11 @@ describe('Area Serializer V2', () => {
                     country: 'HND',
                     region: '8',
                     subregion: '4',
-                    source: { provider: 'gadm', version: '3.6' },
                 },
                 admin: {
                     adm0: 'HND',
                     adm1: 8,
                     adm2: 4,
-                    source: { provider: 'gadm', version: '3.6' },
                 }
             });
         });

--- a/config/test.json
+++ b/config/test.json
@@ -1,1 +1,8 @@
-{}
+{
+  "logger": {
+    "name": "gfw-area-TEST",
+    "level": "fatal",
+    "toFile": false,
+    "dirLogFile": null
+  }
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,7 +29,7 @@ export default [...compat.extends("airbnb", "plugin:mocha/recommended"), {
             afterEach: true,
         },
 
-        ecmaVersion: 2020,
+        ecmaVersion: 2022,
         sourceType: "module",
     },
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "koa-send": "^5.0.1",
     "koa-simple-healthcheck": "0.0.1",
     "koa-validate": "^1.0.7",
+    "lodash": "^4.17.21",
     "moment": "^2.29.3",
     "mongoose": "^5.11.8",
     "mongoose-history": "^0.8.0",


### PR DESCRIPTION
[GTC-3094](https://gfw.atlassian.net/browse/GTC-3094)

# Specific Notes on New Behavior
## Router
When creating or updating a new Area, the router looks for a `source` property in the `iso` and `admin` object. This is important for saving the correct version in the `adminVerisons` collection.

## Serializer
When serializing the new Area (so that a representation can be returned), the serializer is given the `AdministrativeVersion,` which represents the `source` passed to it in the payload.

## Model
I had options to keep the source close to the model during Area creation or updating. I first looked into [Mongoose Virtuals](https://mongoosejs.com/docs/tutorials/virtuals.html). But it didn't quite fit our odd use case. Therefore, I added the `source` to the V2 schema as an optional attribute of an `iso` or `admin` object.

Its primary use is to store the source information provided when creating a new Area or updating the administrative information of an existing one.

## Area Entity
I added a method to gather the source info from a model during creation or an update. GADM 3.6 is always the default for backward compatibility.

