### PR TITLE
Gtc 3157 use admin version when getting areas contd

### DIFF
--- a/app/src/entities/areaV2.entity.js
+++ b/app/src/entities/areaV2.entity.js
@@ -165,6 +165,12 @@ class AreaEntity {
         }
     }
 
+    hasAdminVersion(adminVersion) {
+        return Boolean(this.areaModel.adminVersions.find(
+            (v) => adminVersion.equals(new AdministrativeVersion(v))
+        ));
+    }
+
     /**
      * Populates administrative boundary information (ISO codes, admin hierarchy, geostore, and name)
      * on this instance's `areaModel` based on the provided adminVersion.
@@ -217,10 +223,6 @@ class AreaEntity {
         const adminInfo = this.areaModel.adminVersions.find(
             (v) => adminVersion.equals(new AdministrativeVersion(v))
         );
-
-        if (!adminInfo) { // didn't find the requested version but there are others
-            return;
-        }
 
         const {
             provider, version, country, region, subregion, geostore

--- a/app/src/routes/api/v2/area.router.js
+++ b/app/src/routes/api/v2/area.router.js
@@ -52,6 +52,16 @@ function getFilters(ctx) {
         filter.env = { $in: env.split(',').map((elem) => elem.trim()) };
     }
 
+    // find 1) all custom areas and 2) all administrative boundaries for the administrative provider and version requested
+    const provider = query['source[provider]'] ?? 'gadm';
+    const version = query['source[version]'] ?? '3.6';
+    filter.$or = [
+        { adminVersions: { $elemMatch: { provider, version } } }, // Matches provider & version
+        { adminVersions: { $exists: false } }, // Field does not exist
+        { adminVersions: null }, // Field is explicitly null
+        { adminVersions: { $size: 0 } } // Empty array
+    ];
+
     return filter;
 }
 
@@ -110,6 +120,9 @@ class AreaRouterV2 {
         const page = query['page[number]'] ? parseInt(query['page[number]'], 10) : 1;
         const limit = query['page[size]'] ? parseInt(query['page[size]'], 10) : 300;
 
+        const provider = query['source[provider]'] ?? 'gadm';
+        const version = query['source[version]'] ?? '3.6';
+
         const clonedQuery = { ...ctx.query };
         delete clonedQuery['page[size]'];
         delete clonedQuery['page[number]'];
@@ -122,7 +135,7 @@ class AreaRouterV2 {
         const areas = await AreaModel.paginate(filter, { page, limit, sort: filteredSort });
 
         await Promise.all(areas.docs.map((el) => SubscriptionService.mergeSubscriptionSpecificProps(el, ctx.request.headers['x-api-key'])));
-        ctx.body = AreaSerializerV2.serialize(areas, link);
+        ctx.body = AreaSerializerV2.serialize(areas, link, new AdministrativeVersion({ provider, version }));
     }
 
     static async get(ctx) {
@@ -132,9 +145,23 @@ class AreaRouterV2 {
             ctx.throw(404, 'Area not found');
         }
 
+        const provider = ctx.query['source[provider]'] ?? 'gadm';
+        const version = ctx.query['source[version]'] ?? '3.6';
+
         // 1. Check for area in areas
         let area = await AreaModel.findById(ctx.params.id);
         const areaExists = area !== null;
+
+        // Throws an error if the area is an administrative boundary but lacks the requested admin boundary provider and version
+        if (areaExists) {
+            const areaEntity = new AreaEntity(area);
+            const requestedVersion = new AdministrativeVersion({ provider, version });
+            const hasRequestedVersion = areaEntity.hasAdminVersion(requestedVersion);
+            const isAdministrativeBoundary = areaEntity.isAdministrativeBoundary();
+            if (isAdministrativeBoundary && !hasRequestedVersion) {
+                ctx.throw(406, 'Requested administrative boundary provider or version is not available');
+            }
+        }
 
         // 3. if area doesn't exist
         if (!areaExists) {
@@ -183,7 +210,7 @@ class AreaRouterV2 {
         }
 
         area = await SubscriptionService.mergeSubscriptionSpecificProps(area, ctx.request.headers['x-api-key']);
-        ctx.body = AreaSerializerV2.serialize(area);
+        ctx.body = AreaSerializerV2.serialize(area, null, new AdministrativeVersion({ provider, version }));
     }
 
     static async save(ctx) {
@@ -560,9 +587,21 @@ class AreaRouterV2 {
 
     static async getByUserId(ctx) {
         logger.info(`Finding areas of user with id ${ctx.params.userId}`);
-        const userAreas = await AreaModel.find({ userId: { $eq: ctx.params.userId } }).exec();
+        const provider = ctx.query['source[provider]'] ?? 'gadm';
+        const version = ctx.query['source[version]'] ?? '3.6';
 
-        ctx.body = AreaSerializerV2.serialize(userAreas);
+        // find 1) all custom areas and 2) all administrative boundaries for the administrative provider and version requested
+        const userAreas = await AreaModel.find({
+            userId: { $eq: ctx.params.userId },
+            $or: [
+                { adminVersions: { $elemMatch: { provider, version } } }, // Matches provider & version
+                { adminVersions: { $exists: false } }, // Field does not exist
+                { adminVersions: null }, // Field is explicitly null
+                { adminVersions: { $size: 0 } } // Empty array
+            ]
+        }).exec();
+
+        ctx.body = AreaSerializerV2.serialize(userAreas, null, new AdministrativeVersion({ provider, version }));
     }
 
     static async deleteByUserId(ctx) {

--- a/app/test/e2e/v2/get-area-by-id.spec.js
+++ b/app/test/e2e/v2/get-area-by-id.spec.js
@@ -424,6 +424,141 @@ describe('V2 - Get area by id tests', () => {
         });
     });
 
+    context('Administrative Boundaries', () => {
+        describe('Specifying An Administrative Boundary Version', () => {
+            context('When An Area Has Two Admin Versions', () => {
+                it('returns the version requested', async () => {
+                    nock('https://data-api.globalforestwatch.org')
+                        .get('/political/id-lookup')
+                        .query(() => true)
+                        .reply(200, {
+                            data: {
+                                adminSource: 'GADM',
+                                adminVersion: '4.1',
+                                matches: []
+                            },
+                            status: 'success'
+                        });
+
+                    mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
+                    const area = await new Area(createArea({
+                        userId: USERS.USER.id,
+                        public: true,
+                        name: 'Altamira, Pará, Brazil',
+                        admin: {
+                            adm0: 'BRA',
+                            adm1: 14,
+                            adm2: 8,
+                            source: {
+                                provider: 'gadm',
+                                version: '3.6',
+                            }
+                        },
+                        adminVersions: [
+                            {
+                                provider: 'gadm',
+                                version: '3.6',
+                                country: { id: 'BRA', name: 'Brazil' },
+                                region: { id: 14, name: 'Pará' },
+                                subregion: { id: 8, name: 'Altamira' },
+                            },
+                            {
+                                provider: 'gadm',
+                                version: '4.1',
+                                country: { id: 'BRA', name: 'Brazil' },
+                                region: { id: 15, name: 'Pará' },
+                                subregion: { id: 9, name: 'Altamira' },
+                            }
+                        ]
+                    })).save();
+
+                    const response = await requester
+                        .get(`/api/v2/area/${area.id}?source[provider]=gadm&source[version]=4.1`)
+                        .set('Authorization', 'Bearer abcd')
+                        .set('x-api-key', 'api-key-test');
+
+                    response.status.should.equal(200);
+                    response.body.should.have.property('data').and.be.an('object');
+
+                    response.body.data.should.have.property('type').and.equal('area');
+                    response.body.data.should.have.property('id').and.equal(area.id);
+                    response.body.data.should.have.property('attributes').and.be.an('object');
+
+                    response.body.data.attributes.should.have.property('name').and.equal('Altamira, Pará, Brazil');
+                    response.body.data.attributes.should.have.property('iso').and.be.an('object');
+                    response.body.data.attributes.should.have.property('iso').and.deep.equal({
+                        country: 'BRA',
+                        region: '15',
+                        subregion: '9',
+                        source: {
+                            provider: 'gadm',
+                            version: '4.1',
+                        }
+                    });
+
+                    response.body.data.attributes.should.have.property('admin').and.be.an('object');
+                    response.body.data.attributes.should.have.property('admin').and.deep.equal({
+                        adm0: 'BRA',
+                        adm1: 15,
+                        adm2: 9,
+                        source: {
+                            provider: 'gadm',
+                            version: '4.1',
+                        }
+                    });
+                });
+            });
+            context('When An Area Only has a GADM 3.6 Version but a GADM 4.1 Version is Requested', () => {
+                it('returns a `406 Not Accepted` because the requested version is not available', async () => {
+                    nock('https://data-api.globalforestwatch.org')
+                        .get('/political/id-lookup')
+                        .query(() => true)
+                        .reply(200, {
+                            data: {
+                                adminSource: 'GADM',
+                                adminVersion: '4.1',
+                                matches: []
+                            },
+                            status: 'success'
+                        });
+                    mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
+                    const area = await new Area(createArea({
+                        userId: USERS.USER.id,
+                        public: true,
+                        name: 'Altamira, Pará, Brazil',
+                        admin: {
+                            adm0: 'BRA',
+                            adm1: 14,
+                            adm2: 8,
+                            source: {
+                                provider: 'gadm',
+                                version: '3.6',
+                            }
+                        },
+                        adminVersions: [
+                            {
+                                provider: 'gadm',
+                                version: '3.6',
+                                country: { id: 'BRA', name: 'Brazil' },
+                                region: { id: 14, name: 'Pará' },
+                                subregion: { id: 8, name: 'Altamira' },
+                            },
+                        ]
+                    })).save();
+
+                    const response = await requester
+                        .get(`/api/v2/area/${area.id}?source[provider]=gadm&source[version]=4.1`)
+                        .set('Authorization', 'Bearer abcd')
+                        .set('x-api-key', 'api-key-test');
+
+                    response.status.should.equal(406);
+                    response.body.should.have.property('errors').and.be.an('array');
+                    response.body.errors[0].should.have.property('detail').and.equal('Requested administrative boundary provider or version is not available');
+                });
+            });
+        });
+    });
+
     afterEach(async () => {
         if (!nock.isDone()) {
             throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);

--- a/app/test/e2e/v2/get-areas.spec.js
+++ b/app/test/e2e/v2/get-areas.spec.js
@@ -413,6 +413,70 @@ describe('V2 - Get areas', () => {
         response.body.data.map((area) => area.id).should.have.members(sortedAreaIds.slice(0, 3));
     });
 
+    describe('Filtering by Administrative Boundary Version', () => {
+        it('adds the admin boundary filter to the links', async () => {
+            const areaOne = await new Area(createArea({ userId: USERS.USER.id })).save();
+            const areaTwo = await new Area(createArea({ userId: USERS.USER.id })).save();
+
+            mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
+
+            const response = await requester
+                .get(`/api/v2/area?source[provider]=gadm&source[version]=3.6`)
+                .set('Authorization', 'Bearer abcd')
+                .set('x-api-key', 'api-key-test');
+
+            response.status.should.equal(200);
+            response.body.should.have.property('data').with.lengthOf(2);
+            response.body.data.map((elem) => elem.id).sort().should.deep.equal([areaOne.id, areaTwo.id].sort());
+            response.body.should.have.property('data').and.be.an('array');
+            response.body.should.have.property('links').and.be.an('object');
+            response.body.links.should.have.property('self').and.equal(`http://127.0.0.1:${config.get('service.port')}/v2/area?source[provider]=gadm&source[version]=3.6&page[number]=1&page[size]=300`);
+            response.body.links.should.have.property('prev').and.equal(`http://127.0.0.1:${config.get('service.port')}/v2/area?source[provider]=gadm&source[version]=3.6&page[number]=1&page[size]=300`);
+            response.body.links.should.have.property('next').and.equal(`http://127.0.0.1:${config.get('service.port')}/v2/area?source[provider]=gadm&source[version]=3.6&page[number]=1&page[size]=300`);
+            response.body.links.should.have.property('first').and.equal(`http://127.0.0.1:${config.get('service.port')}/v2/area?source[provider]=gadm&source[version]=3.6&page[number]=1&page[size]=300`);
+            response.body.links.should.have.property('last').and.equal(`http://127.0.0.1:${config.get('service.port')}/v2/area?source[provider]=gadm&source[version]=3.6&page[number]=1&page[size]=300`);
+        });
+
+        it('only includes administrative boundary areas that match the provider and version', async () => {
+            const areaOne = await new Area(createArea({
+                userId: USERS.USER.id,
+                iso: {
+                    country: 'HND',
+                    source: {
+                        provider: 'gadm',
+                        version: '3.6',
+                    }
+                }
+            })).save();
+
+            // won't be included because it's 4.1
+            await new Area(createArea({
+                userId: USERS.USER.id,
+                iso: {
+                    country: 'HND',
+                    source: {
+                        provider: 'gadm',
+                        version: '4.1',
+                    }
+                }
+            })).save();
+
+            const areaCustom = await new Area(createArea({ userId: USERS.USER.id })).save();
+
+            mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
+
+            const response = await requester
+                .get(`/api/v2/area?source[provider]=gadm&source[version]=3.6`)
+                .set('Authorization', 'Bearer abcd')
+                .set('x-api-key', 'api-key-test');
+
+            response.status.should.equal(200);
+            response.body.should.have.property('data').with.lengthOf(2);
+            response.body.should.have.property('data').and.be.an('array');
+            response.body.data.map((elem) => elem.id).sort().should.deep.equal([areaOne.id, areaCustom.id].sort());
+        });
+    });
+
     describe('Filtering by environments', () => {
         it('Getting areas without an env filter returns areas with env production', async () => {
             await new Area(createArea({ userId: USERS.USER.id, env: 'custom' })).save();


### PR DESCRIPTION
[GTC-3157](https://gfw.atlassian.net/browse/GTC-3157)

Adds the `source[provider]` and `source[version]` administrative boundary query params to our `GET` endpoints.