### PR TITLE
:bug: fix(GetAllAreas): stagger requests to subscriptions microservice

### DIFF
--- a/app/src/routes/api/v2/area.router.js
+++ b/app/src/routes/api/v2/area.router.js
@@ -134,7 +134,17 @@ class AreaRouterV2 {
 
         const areas = await AreaModel.paginate(filter, { page, limit, sort: filteredSort });
 
-        await Promise.all(areas.docs.map((el) => SubscriptionService.mergeSubscriptionSpecificProps(el, ctx.request.headers['x-api-key'])));
+        const delay = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); });
+        await Promise.all(
+            areas.docs.map(async (el, index) => {
+                // Introduce a delay that increases with each index
+                await delay(index * 50); // 50ms delay between each request's start
+                return SubscriptionService.mergeSubscriptionSpecificProps(
+                    el,
+                    ctx.request.headers['x-api-key']
+                );
+            })
+        );
         ctx.body = AreaSerializerV2.serialize(areas, link, new AdministrativeVersion({ provider, version }));
     }
 

--- a/app/src/routes/api/v2/area.router.js
+++ b/app/src/routes/api/v2/area.router.js
@@ -138,7 +138,7 @@ class AreaRouterV2 {
         await Promise.all(
             areas.docs.map(async (el, index) => {
                 // Introduce a delay that increases with each index
-                await delay(index * 50); // 50ms delay between each request's start
+                await delay(index * 25); // 25ms delay between each request's start
                 return SubscriptionService.mergeSubscriptionSpecificProps(
                     el,
                     ctx.request.headers['x-api-key']


### PR DESCRIPTION
When users have a large number of AOIs that they
are subscribed to, it has a very good chance of
spamming the subscriptions microservice.

This is a quick fix to support a group that
needs a fix ASAP. What they are seeing is that
their account in GFW has no areas despite actually having ~150 AOIs associated with their userID.

As an Admin, you can replicate their behavior by
getting all subscriptions and sorting by
`subscriptionId`:

curl --location 'https://api.resourcewatch.org/v2/area?all=true&sort=-subscriptionId' \ --header 'Authorization: Bearer ****'

This fails because all the areas with a
subscription are returned first causing the
subscriptions microservice to return a 429:
Too Many Requests