### PR TITLE
Fix Ignore 429s from subscription service

### DIFF
--- a/app/src/routes/api/v2/area.router.js
+++ b/app/src/routes/api/v2/area.router.js
@@ -134,17 +134,7 @@ class AreaRouterV2 {
 
         const areas = await AreaModel.paginate(filter, { page, limit, sort: filteredSort });
 
-        const delay = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); });
-        await Promise.all(
-            areas.docs.map(async (el, index) => {
-                // Introduce a delay that increases with each index
-                await delay(index * 50); // 50ms delay between each request's start
-                return SubscriptionService.mergeSubscriptionSpecificProps(
-                    el,
-                    ctx.request.headers['x-api-key']
-                );
-            })
-        );
+        await Promise.all(areas.docs.map((el) => SubscriptionService.mergeSubscriptionSpecificProps(el, ctx.request.headers['x-api-key'])));
         ctx.body = AreaSerializerV2.serialize(areas, link, new AdministrativeVersion({ provider, version }));
     }
 

--- a/app/src/routes/api/v2/area.router.js
+++ b/app/src/routes/api/v2/area.router.js
@@ -138,7 +138,7 @@ class AreaRouterV2 {
         await Promise.all(
             areas.docs.map(async (el, index) => {
                 // Introduce a delay that increases with each index
-                await delay(index * 25); // 25ms delay between each request's start
+                await delay(index * 50); // 50ms delay between each request's start
                 return SubscriptionService.mergeSubscriptionSpecificProps(
                     el,
                     ctx.request.headers['x-api-key']

--- a/app/src/services/subscription.service.js
+++ b/app/src/services/subscription.service.js
@@ -6,15 +6,21 @@ const AreaModel = require('models/area.modelV2');
 class SubscriptionsService {
 
     static async mergeSubscriptionSpecificProps(area, apiKey) {
-        // Set default values
-        area.confirmed = false;
+        try {
+            // Set default values
+            area.confirmed = false;
 
-        // Find any subscription only props (such as confirmed) and merge them to the area being returned
-        if (area.subscriptionId) {
-            const [sub] = await SubscriptionsService.findByIds([area.subscriptionId], apiKey);
-            return sub ? SubscriptionsService.mergeSubscriptionOverArea(area, { ...sub.attributes, id: sub.id }) : area;
+            // Find any subscription only props (such as confirmed) and merge them to the area being returned
+            if (area.subscriptionId) {
+                const [sub] = await SubscriptionsService.findByIds([area.subscriptionId], apiKey);
+                return sub ? SubscriptionsService.mergeSubscriptionOverArea(area, {
+                    ...sub.attributes,
+                    id: sub.id
+                }) : area;
+            }
+        } catch (e) {
+            logger.warn(`Error while finding and merging subscription with id ${area.id}.`, e);
         }
-
         return area;
     }
 
@@ -216,7 +222,7 @@ class SubscriptionsService {
             });
 
             return updatedSubscription.data.id;
-        } catch (e) {
+        } catch {
             logger.warn(`Error while updating subscription with id ${area.subscriptionId} associated with area with id ${area._id}.`);
             return null;
         }
@@ -231,7 +237,7 @@ class SubscriptionsService {
                     'x-api-key': apiKey
                 }
             });
-        } catch (e) {
+        } catch {
             logger.warn(`Error while deleting subscription with id ${id}.`);
         }
     }


### PR DESCRIPTION
The request throttling did work by reducing the 429s. However, it's just a little too long to process the areas and results in timeout errors. We thought that might happen but wanted to still try.

This fix reverts the throttling and instead just ignores the 429s.
We don't think that the syncing for a user actually happens that much for v2 and is pretty wasteful to happen with every single get. 

We're working on a better redesign, regardless. It would be much better to find all the subscriptions in one batch.