### PR TITLE
GTC-3258: Re-enable Area Subscription Sync

### DIFF
--- a/app/src/routes/api/v2/area.router.js
+++ b/app/src/routes/api/v2/area.router.js
@@ -134,8 +134,7 @@ class AreaRouterV2 {
 
         const areas = await AreaModel.paginate(filter, { page, limit, sort: filteredSort });
 
-        // This is temporary. The mergeSubscriptionSpecification is spamming the subscription service. A batch design is needed
-        // await Promise.all(areas.docs.map((el) => SubscriptionService.mergeSubscriptionSpecificProps(el, ctx.request.headers['x-api-key'])));
+        await Promise.all(areas.docs.map((el) => SubscriptionService.mergeSubscriptionSpecificProps(el, ctx.request.headers['x-api-key'])));
         ctx.body = AreaSerializerV2.serialize(areas, link, new AdministrativeVersion({ provider, version }));
     }
 

--- a/app/src/routes/api/v2/area.router.js
+++ b/app/src/routes/api/v2/area.router.js
@@ -134,7 +134,7 @@ class AreaRouterV2 {
 
         const areas = await AreaModel.paginate(filter, { page, limit, sort: filteredSort });
 
-        await Promise.all(areas.docs.map((el) => SubscriptionService.mergeSubscriptionSpecificProps(el, ctx.request.headers['x-api-key'])));
+        await SubscriptionService.mergeSubscriptionSpecificProps(areas.docs, ctx.request.headers['x-api-key']);
         ctx.body = AreaSerializerV2.serialize(areas, link, new AdministrativeVersion({ provider, version }));
     }
 
@@ -178,12 +178,6 @@ class AreaRouterV2 {
                 ...subscription.attributes,
                 id: subscription.id
             });
-
-            // 2. If area exists
-            // if it has subscription get subscription also and merge props
-            // if it doesn't have subscription just return the area
-        } else if (area.subscriptionId) {
-            area = await SubscriptionService.mergeSubscriptionSpecificProps(area, ctx.request.headers['x-api-key']);
         }
 
         const user = ctx.state.loggedUser || null;
@@ -209,7 +203,7 @@ class AreaRouterV2 {
             area.subscriptionId = null;
         }
 
-        area = await SubscriptionService.mergeSubscriptionSpecificProps(area, ctx.request.headers['x-api-key']);
+        [area] = await SubscriptionService.mergeSubscriptionSpecificProps([area], ctx.request.headers['x-api-key']);
         ctx.body = AreaSerializerV2.serialize(area, null, new AdministrativeVersion({ provider, version }));
     }
 
@@ -351,7 +345,7 @@ class AreaRouterV2 {
             }
         }
 
-        area = await SubscriptionService.mergeSubscriptionSpecificProps(area, ctx.request.headers['x-api-key']);
+        [area] = await SubscriptionService.mergeSubscriptionSpecificProps([area], ctx.request.headers['x-api-key']);
         const administrativeVersion = new AdministrativeVersion(new AreaEntity(area).gatherSourceInfo());
         ctx.body = AreaSerializerV2.serialize(area, null, administrativeVersion);
 
@@ -525,7 +519,7 @@ class AreaRouterV2 {
             area = await area.save();
         }
 
-        area = await SubscriptionService.mergeSubscriptionSpecificProps(area, ctx.request.headers['x-api-key']);
+        [area] = await SubscriptionService.mergeSubscriptionSpecificProps([area], ctx.request.headers['x-api-key']);
         const administrativeVersion = new AdministrativeVersion(new AreaEntity(area).gatherSourceInfo());
         ctx.body = AreaSerializerV2.serialize(area, null, administrativeVersion);
 

--- a/app/src/services/subscription.service.js
+++ b/app/src/services/subscription.service.js
@@ -5,23 +5,53 @@ const AreaModel = require('models/area.modelV2');
 
 class SubscriptionsService {
 
-    static async mergeSubscriptionSpecificProps(area, apiKey) {
+    /**
+     * Merges subscription-specific properties into corresponding area objects.
+     *
+     * This method:
+     * 1. Organizes areas by their subscriptionId
+     * 2. Marks all areas as unconfirmed (confirmed = false)
+     * 3. Fetches subscription data for all unique subscription IDs
+     * 4. Merges subscription attributes into their corresponding area objects
+     *
+     * @static
+     * @async
+     * @function mergeSubscriptionSpecificProps
+     * @param {Array<Object>} areas - Array of area objects to process. Each area may contain a subscriptionId.
+     * @param {string} apiKey - API key used for authenticating with the SubscriptionsService.
+     * @returns {Promise<Array<Object>>} The original areas array with subscription data merged where applicable.
+     */
+    static async mergeSubscriptionSpecificProps(areas, apiKey) {
         try {
-            // Set default values
-            area.confirmed = false;
+            const areasBySubscriptionId = {};
+            areas.forEach((area) => {
+                const subId = area.subscriptionId;
+                area.confirmed = false;
+                if (subId) {
+                    areasBySubscriptionId[subId] = area;
+                }
+            });
 
-            // Find any subscription only props (such as confirmed) and merge them to the area being returned
-            if (area.subscriptionId) {
-                const [sub] = await SubscriptionsService.findByIds([area.subscriptionId], apiKey);
-                return sub ? SubscriptionsService.mergeSubscriptionOverArea(area, {
-                    ...sub.attributes,
-                    id: sub.id
-                }) : area;
+            const subscriptionIds = Object.keys(areasBySubscriptionId);
+            if (subscriptionIds.length === 0) {
+                return areas;
             }
+
+            const subscriptions = await SubscriptionsService.findByIds(subscriptionIds, apiKey);
+            subscriptions?.forEach((subscription) => {
+                SubscriptionsService.mergeSubscriptionOverArea(
+                    areasBySubscriptionId[subscription.id],
+                    {
+                        ...subscription.attributes,
+                        id: subscription.id,
+                    }
+                );
+            });
         } catch (e) {
-            logger.warn(`Error while finding and merging subscription with id ${area.id}.`, e);
+            logger.warn('Error while batch finding and merging subscriptions.', e);
         }
-        return area;
+
+        return areas;
     }
 
     static getRequestBodyForSubscriptionFromArea(area) {

--- a/app/test/e2e/v2/area-status.spec.js
+++ b/app/test/e2e/v2/area-status.spec.js
@@ -117,7 +117,7 @@ describe('V2 - Area status', () => {
         })).save();
 
         // Mock the test area
-        mockSubscriptionFindByIds([id], { userId: USERS.USER.id, params: { wdpaid: '123' } }, 2);
+        mockSubscriptionFindByIds([id], { userId: USERS.USER.id, params: { wdpaid: '123' } });
         const response = await requester.get(`/api/v2/area/${testArea.id}`).set('Authorization', 'Bearer abcd')
             .set('x-api-key', 'api-key-test');
         response.status.should.equal(200);
@@ -140,7 +140,7 @@ describe('V2 - Area status', () => {
         })).save();
 
         // Mock the test area
-        mockSubscriptionFindByIds([subId], { userId: USERS.USER.id, params: { geostore: '123' } }, 2);
+        mockSubscriptionFindByIds([subId], { userId: USERS.USER.id, params: { geostore: '123' } });
         const response = await requester.get(`/api/v2/area/${testArea.id}`).set('Authorization', 'Bearer abcd')
             .set('x-api-key', 'api-key-test');
         response.status.should.equal(200);

--- a/app/test/e2e/v2/get-areas.spec.js
+++ b/app/test/e2e/v2/get-areas.spec.js
@@ -202,9 +202,7 @@ describe('V2 - Get areas', () => {
         response.body.data.should.have.property('syncedAreas').and.equal(1);
         response.body.data.should.have.property('createdAreas').and.equal(2);
 
-        mockSubscriptionFindByIds([subId1], { userId: USERS.USER.id });
-        mockSubscriptionFindByIds([subId2], { userId: USERS.USER.id });
-        mockSubscriptionFindByIds([subId3], { userId: USERS.USER.id });
+        mockSubscriptionFindByIds([subId1, subId2, subId3], { userId: USERS.USER.id });
 
         // Get all areas
         const getResponse = await requester.get('/api/v2/area?all=true').set('Authorization', 'Bearer abcd')
@@ -330,7 +328,7 @@ describe('V2 - Get areas', () => {
         response.body.data.should.have.property('syncedAreas').and.equal(0);
         response.body.data.should.have.property('createdAreas').and.equal(3);
 
-        mockSubscriptionFindByIds([id1], { userId: USERS.USER.id }, 3);
+        mockSubscriptionFindByIds([id1, id2, id3], { userId: USERS.USER.id });
         const getResponse = await requester.get('/api/v2/area?all=true').set('Authorization', 'Bearer abcd')
             .set('x-api-key', 'api-key-test');
         getResponse.status.should.equal(200);
@@ -367,7 +365,7 @@ describe('V2 - Get areas', () => {
         syncResponse.body.data.should.have.property('createdAreas').and.equal(3);
 
         // Requesting all areas => should return 5 areas
-        mockSubscriptionFindByIds([id1], { userId: USERS.USER.id }, 3);
+        mockSubscriptionFindByIds([id1, id2, id3], { userId: USERS.USER.id });
         const response = await requester
             .get(`/api/v2/area?all=true`)
             .set('Authorization', 'Bearer abcd')
@@ -376,9 +374,7 @@ describe('V2 - Get areas', () => {
         response.body.should.have.property('data').and.be.an('array').and.have.length(5);
 
         // Requesting all areas with status saved => should return 1 area
-        mockSubscriptionFindByIds([id1], { userId: USERS.USER.id });
-        mockSubscriptionFindByIds([id2], { userId: USERS.USER.id });
-        mockSubscriptionFindByIds([id3], { userId: USERS.USER.id });
+        mockSubscriptionFindByIds([id1, id2, id3], { userId: USERS.USER.id });
         const savedResponse = await requester
             .get(`/api/v2/area?all=true&status=saved`)
             .set('Authorization', 'Bearer abcd')

--- a/app/test/e2e/v2/get-areas.spec.js
+++ b/app/test/e2e/v2/get-areas.spec.js
@@ -17,6 +17,7 @@ chai.should();
 const { getTestServer } = require('../utils/test-server');
 const {
     mockSubscriptionFindAll,
+    mockSubscriptionFindByIds,
 } = require('../utils/helpers');
 
 nock.disableNetConnect();
@@ -143,6 +144,7 @@ describe('V2 - Get areas', () => {
         const area1 = await new Area(createArea({ userId: USERS.USER.id })).save();
         const area2 = await new Area(createArea({ userId: USERS.USER.id, subscriptionId: subId })).save();
 
+        mockSubscriptionFindByIds([subId], { userId: USERS.USER.id });
         const response = await requester.get('/api/v2/area').set('Authorization', 'Bearer abcd')
             .set('x-api-key', 'api-key-test');
         response.status.should.equal(200);
@@ -199,6 +201,10 @@ describe('V2 - Get areas', () => {
         response.body.should.have.property('data').and.be.an('object');
         response.body.data.should.have.property('syncedAreas').and.equal(1);
         response.body.data.should.have.property('createdAreas').and.equal(2);
+
+        mockSubscriptionFindByIds([subId1], { userId: USERS.USER.id });
+        mockSubscriptionFindByIds([subId2], { userId: USERS.USER.id });
+        mockSubscriptionFindByIds([subId3], { userId: USERS.USER.id });
 
         // Get all areas
         const getResponse = await requester.get('/api/v2/area?all=true').set('Authorization', 'Bearer abcd')
@@ -324,6 +330,7 @@ describe('V2 - Get areas', () => {
         response.body.data.should.have.property('syncedAreas').and.equal(0);
         response.body.data.should.have.property('createdAreas').and.equal(3);
 
+        mockSubscriptionFindByIds([id1], { userId: USERS.USER.id }, 3);
         const getResponse = await requester.get('/api/v2/area?all=true').set('Authorization', 'Bearer abcd')
             .set('x-api-key', 'api-key-test');
         getResponse.status.should.equal(200);
@@ -360,6 +367,7 @@ describe('V2 - Get areas', () => {
         syncResponse.body.data.should.have.property('createdAreas').and.equal(3);
 
         // Requesting all areas => should return 5 areas
+        mockSubscriptionFindByIds([id1], { userId: USERS.USER.id }, 3);
         const response = await requester
             .get(`/api/v2/area?all=true`)
             .set('Authorization', 'Bearer abcd')
@@ -368,6 +376,9 @@ describe('V2 - Get areas', () => {
         response.body.should.have.property('data').and.be.an('array').and.have.length(5);
 
         // Requesting all areas with status saved => should return 1 area
+        mockSubscriptionFindByIds([id1], { userId: USERS.USER.id });
+        mockSubscriptionFindByIds([id2], { userId: USERS.USER.id });
+        mockSubscriptionFindByIds([id3], { userId: USERS.USER.id });
         const savedResponse = await requester
             .get(`/api/v2/area?all=true&status=saved`)
             .set('Authorization', 'Bearer abcd')

--- a/app/test/e2e/v2/get-single-area.spec.js
+++ b/app/test/e2e/v2/get-single-area.spec.js
@@ -109,7 +109,7 @@ describe('V2 - Get single area', () => {
             userId: USERS.USER.id,
             name: 'Subscription name',
             confirmed: false,
-        }, 2);
+        });
 
         const response = await requester.get(`/api/v2/area/${area.id}`).set('Authorization', 'Bearer abcd')
             .set('x-api-key', 'api-key-test');
@@ -130,7 +130,7 @@ describe('V2 - Get single area', () => {
             userId: USERS.USER.id,
             subscriptionId: fakeId,
         })).save();
-        mockSubscriptionFindByIds([], {}, 2);
+        mockSubscriptionFindByIds([], {});
 
         const response = await requester.get(`/api/v2/area/${area.id}`).set('Authorization', 'Bearer abcd')
             .set('x-api-key', 'api-key-test');

--- a/app/test/e2e/v2/sync-areas.spec.js
+++ b/app/test/e2e/v2/sync-areas.spec.js
@@ -64,8 +64,7 @@ describe('V2 - Sync areas', () => {
         response3.body.errors[0].should.have.property('detail').and.equal(`Not authorized`);
     });
 
-    // temporarily pause
-    xit('Sync areas as an ADMIN updates the areas in the database with overwrite information from associated subscriptions, returning the number of synced areas', async () => {
+    it('Sync areas as an ADMIN updates the areas in the database with overwrite information from associated subscriptions, returning the number of synced areas', async () => {
         mockValidateRequestWithApiKeyAndUserToken({ user: USERS.ADMIN });
         mockValidateRequestWithApiKeyAndUserToken({ user: USERS.ADMIN });
 
@@ -99,8 +98,7 @@ describe('V2 - Sync areas', () => {
         getResponse.body.data.find((area) => area.id === area3.id).attributes.should.have.property('name').and.equal('Old Name 3');
     });
 
-    // temporarily pause
-    xit('Sync areas as an ADMIN creates new areas in the database with subscriptions that do not have a match with an existing area, returning the number of created areas', async () => {
+    it('Sync areas as an ADMIN creates new areas in the database with subscriptions that do not have a match with an existing area, returning the number of created areas', async () => {
         mockValidateRequestWithApiKeyAndUserToken({ user: USERS.ADMIN });
         mockValidateRequestWithApiKeyAndUserToken({ user: USERS.ADMIN });
 

--- a/app/test/e2e/v2/sync-areas.spec.js
+++ b/app/test/e2e/v2/sync-areas.spec.js
@@ -86,9 +86,7 @@ describe('V2 - Sync areas', () => {
         validateSyncSuccessResponse(response, 3, 0, 3, [area1.id, area2.id, area3.id]);
 
         // Getting the subscription now returns the synced information
-        mockSubscriptionFindByIds([subId1], { userId: USERS.USER.id });
-        mockSubscriptionFindByIds([subId2], { userId: USERS.USER.id });
-        mockSubscriptionFindByIds([subId3], { userId: USERS.USER.id });
+        mockSubscriptionFindByIds([subId1, subId2, subId3], { userId: USERS.USER.id });
         const getResponse = await requester.get(`/api/v2/area?all=true`).set('Authorization', 'Bearer abcd')
             .set('x-api-key', 'api-key-test');
         getResponse.status.should.equal(200);
@@ -120,9 +118,7 @@ describe('V2 - Sync areas', () => {
         validateSyncSuccessResponse(response, 0, 3, 3);
 
         // Getting the subscription now returns the synced information
-        mockSubscriptionFindByIds([id1], { userId: USERS.USER.id });
-        mockSubscriptionFindByIds([id2], { userId: USERS.USER.id });
-        mockSubscriptionFindByIds([id3], { userId: USERS.USER.id });
+        mockSubscriptionFindByIds([id1, id2, id3], { userId: USERS.USER.id });
         const getResponse = await requester.get(`/api/v2/area?all=true`).set('Authorization', 'Bearer abcd')
             .set('x-api-key', 'api-key-test');
         getResponse.status.should.equal(200);


### PR DESCRIPTION
This is a more correct approach to merging many Areas with the Subscription Service.
Before disabling the merge, users with many areas would cause significant stress on the Subscription Service when using the `v2/areas` route (get all areas). 

This stress manifested in significant numbers of `429 Too Many Requests` errors originating from the Subscriptions Service.

In the case of Flagship users, they would get an error page on my-gfw saying that they didn't have any areas. 😱 
Additionally, the abuse slows down the server and would occasionally result in `503 Timeout` errors happening if the Areas request couldn't finish within 30 seconds (AWS timeout constraint).

With the merging disabled, Flagship users are seeing their Areas with Subscriptions showing as _unconfirmed_ and needing email confirmation. However, this isn't true. The merging is needed to set `confirmed` to `true`.

This PR will result in merging resuming using a batch strategy, and it will mark the appropriate Areas as `confirmed`.

See the JSDoc in the PR.