### PR TITLE
GTC-3262: Remove `geostore` Property When Saving or Updating a GADM 4.1 Area

### DIFF
--- a/app/src/validators/area.validatorV2.js
+++ b/app/src/validators/area.validatorV2.js
@@ -18,7 +18,7 @@ class AreaValidatorV2 {
     static isArray(property) {
         if (property instanceof Array) {
             const invalid = property.filter((str) => {
-                const regex = RegExp(/^[a-zA-Z0-9\u00C0-\u024F\u1E00-\u1EFF_ ]*$/i);
+                const regex = /^[a-zA-Z0-9\u00C0-\u024F\u1E00-\u1EFF_ ]*$/i;
                 return (typeof str !== 'string' || !regex.test(str));
             });
             return (invalid.length === 0);
@@ -26,14 +26,53 @@ class AreaValidatorV2 {
         return false;
     }
 
+    /**
+     * Removes the geostore from the request body if the area is a GADM 4.1 administrative boundary.
+     *
+     * This function checks if either the ISO or admin fields in the request body specify a GADM 4.1 source.
+     * If so, it sets the geostore field to null so that arbitrary geostores cannot be used when actual
+     * administrative boundaries are specified.
+     *
+     * @param {Object} ctx - The Koa context object containing the request/response
+     * @param {Object} ctx.request.body - The request body payload
+     * @param {string|null} ctx.request.body.geostore - The existing geostore ID (optional)
+     * @param {Object} [ctx.request.body.iso] - ISO country data (optional)
+     * @param {Object} [ctx.request.body.iso.source] - ISO data source information
+     * @param {Object} [ctx.request.body.admin] - Admin area data (optional)
+     * @param {Object} [ctx.request.body.admin.source] - Admin area source information
+     *
+     * @example
+     * // When processing a GADM 4.1 admin area request:
+     * remove_geostore_from_admin_area(ctx);
+     * // ctx.request.body.geostore will be set to null
+     */
+    static remove_geostore_from_admin_area(ctx) {
+        if (!ctx.request.body.geostore) return;
+
+        const { iso, admin } = ctx.request.body;
+        const sourceIsGadm41 = (source) => source?.provider?.toLowerCase().trim() === 'gadm'
+            && source?.version?.toLowerCase().trim() === '4.1';
+
+        const isGadm41Area = sourceIsGadm41(iso?.source) || sourceIsGadm41(admin?.source);
+
+        if (isGadm41Area) {
+            ctx.request.body.geostore = null;
+        }
+    }
+
     static async create(ctx, next) {
         logger.debug('Validating body for create area');
         ctx.checkBody('name').notEmpty().len(1, 100);
         ctx.checkBody('application').optional().check((application) => AreaValidatorV2.notEmptyString(application), 'cannot be empty');
 
+        AreaValidatorV2.remove_geostore_from_admin_area(ctx);
+
         // Validate geostore field as hexadecimal only if present
         ctx.checkBody('geostore').optional();
-        if (ctx.request.body.geostore) { ctx.checkBody('geostore').isHexadecimal(); }
+        if (ctx.request.body.geostore) {
+            ctx.checkBody('geostore').isHexadecimal();
+        }
+
         ctx.checkBody('geostoreDataApi').optional();
 
         // Validate geostore and geostoreDataApi were not provided at the same time
@@ -88,6 +127,8 @@ class AreaValidatorV2 {
         logger.debug('Validating body for update area');
         ctx.checkBody('name').optional().len(2, 100);
         ctx.checkBody('application').optional().check((application) => AreaValidatorV2.notEmptyString(application), 'cannot be empty');
+
+        AreaValidatorV2.remove_geostore_from_admin_area(ctx);
 
         // Validate geostore field as hexadecimal only if present
         ctx.checkBody('geostore').optional();

--- a/app/test/e2e/v2/create-area.spec.js
+++ b/app/test/e2e/v2/create-area.spec.js
@@ -107,6 +107,55 @@ describe('V2 - Create area', () => {
             response.body.data.attributes.should.have.property('updatedAt');
             new Date(response.body.data.attributes.updatedAt).should.closeToTime(new Date(response.body.data.attributes.createdAt), 5);
         });
+
+        it('sets the `geostore` to null if there is `admin` information', async () => {
+            mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
+
+            const response = await requester
+                .post(`/api/v2/area`)
+                .set('Authorization', 'Bearer abcd')
+                .set('x-api-key', 'api-key-test')
+                .send({
+                    name: 'Portugal area',
+                    geostore: '324748a3-dd57-4abe-8f03-6a5d7685680d',
+                    admin: {
+                        adm0: 'createdCountryIso',
+                        source: {
+                            provider: 'gadm',
+                            version: '4.1',
+                        }
+                    },
+                });
+
+            response.status.should.equal(200);
+            response.body.should.have.property('data').and.be.an('object');
+            response.body.data.attributes.should.have.property('geostore').and.equal(null);
+        });
+
+        it('sets the `geostore` to null if there is `iso` information', async () => {
+            mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
+
+            const response = await requester
+                .post(`/api/v2/area`)
+                .set('Authorization', 'Bearer abcd')
+                .set('x-api-key', 'api-key-test')
+                .send({
+                    name: 'Portugal area',
+                    geostore: '324748a3-dd57-4abe-8f03-6a5d7685680d',
+                    iso: {
+                        country: 'createdCountryIso',
+                        region: 'createdRegionIso',
+                        source: {
+                            provider: 'gadm',
+                            version: '4.1',
+                        }
+                    },
+                });
+
+            response.status.should.equal(200);
+            response.body.should.have.property('data').and.be.an('object');
+            response.body.data.attributes.should.have.property('geostore').and.equal(null);
+        });
     });
 
     describe('Explicitly Create A GADM 3.6 Administrative Area', () => {
@@ -453,6 +502,7 @@ describe('V2 - Create area', () => {
             });
         });
 
+        // eslint-disable-next-line max-len
         it('Creating an area with custom env and with a file while being logged in as a user that owns the area should upload the image to S3 and return a 200 HTTP code and the created area object with the custom env', async () => {
             mockValidateRequestWithApiKeyAndUserToken({ user: USERS.USER });
 

--- a/app/test/e2e/v2/update-area.spec.js
+++ b/app/test/e2e/v2/update-area.spec.js
@@ -169,7 +169,7 @@ describe('V2 - Update area', () => {
             response.body.data.should.have.property('id').and.equal(testArea.id);
             response.body.data.attributes.should.have.property('name').and.equal('Portugal area');
             response.body.data.attributes.should.have.property('application').and.equal('rw');
-            response.body.data.attributes.should.have.property('geostore').and.equal('713899292fc118a915741728ef84a2a7');
+            response.body.data.attributes.should.have.property('geostore').and.equal(null);
             response.body.data.attributes.should.have.property('userId').and.equal(testArea.userId);
             response.body.data.attributes.should.have.property('wdpaid').and.equal(3);
             response.body.data.attributes.should.have.property('use').and.deep.equal({
@@ -233,7 +233,7 @@ describe('V2 - Update area', () => {
             response.body.data.should.have.property('id').and.equal(testArea.id);
             response.body.data.attributes.should.have.property('name').and.equal('Portugal area');
             response.body.data.attributes.should.have.property('application').and.equal('rw');
-            response.body.data.attributes.should.have.property('geostore').and.equal('713899292fc118a915741728ef84a2a7');
+            response.body.data.attributes.should.have.property('geostore').and.equal(null);
             response.body.data.attributes.should.have.property('userId').and.equal(testArea.userId);
             response.body.data.attributes.should.have.property('wdpaid').and.equal(3);
             response.body.data.attributes.should.have.property('use').and.deep.equal({


### PR DESCRIPTION
GADM 4.1 admin geostores are now managed in the Data API.
As such, the ID/Hash is a UUID. This breaks the Areas MS validation for new Areas.
A UUID is not considered a hexadecimal number.

Being able to specify a `geostore` and admin information can lead to confusing results. 
Therefore, if a user sets admin/iso information, the geostore value will be removed. 
This allows analysis to happen on the full res admin boundary (as it should).